### PR TITLE
feat: redesign order page layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="Images/Icon.ico">
-    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
 </head>
 
 <!-- Google tag (gtag.js) -->
@@ -40,7 +39,7 @@
   gtag('config', 'G-KFVXYQESC0');
 </script>
 
-<body>
+<body class="about-page">
 
     <header>
         <div class="logo">
@@ -52,6 +51,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>
+                <li><a href="order.html">Order</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
@@ -59,19 +59,114 @@
         <div class="hamburger">☰</div>
     </header>
 
-    <main class="page-content">
-        <section class="about-section">
-            <h2 data-aos="fade-up">About The Boba Lab</h2>
-            <div class="about-container">
-                <div class="about-image" data-aos="fade-right">
-                    <img src="Images/AboutUs.webp" alt="Tim The Boba Lab sedang menyiapkan minuman">
+    <main class="about-main">
+        <section class="page-hero about-hero">
+            <div class="hero-inner" data-animate>
+                <p class="eyebrow">Our Story</p>
+                <h1>Menjadikan Setiap Tegukan Sebuah Eksperimen Rasa</h1>
+                <p>Kami memulai perjalanan sebagai komunitas pecinta boba yang gemar mengutak-atik resep. Kini, laboratorium rasa kami menghadirkan minuman premium yang konsisten dan selalu segar.</p>
+                <div class="hero-actions">
+                    <a class="btn primary" href="order.html">Cicipi Menu Kami</a>
+                    <a class="btn ghost" href="#timeline">Perjalanan Boba Lab</a>
                 </div>
-                <div class="about-text" data-aos="fade-left">
-                    <h3 data-aos="fade-left" data-aos-delay="200">Visi Kami: Inovasi Rasa di Boba Lab</h3>
-                    <p data-aos="fade-left" data-aos-delay="300">Di <b>Boba Lab</b>, kami adalah para pencipta, penjelajah rasa, dan penggemar boba sejati. Kami percaya bahwa boba bukanlah sekadar minuman, melainkan sebuah seni yang terus berkembang. Visi kami adalah menjadi pionir dalam dunia boba, menghadirkan inovasi dan kualitas tanpa kompromi.</p>
-                    <p data-aos="fade-left" data-aos-delay="400">Kami berkomitmen penuh pada keunggulan, mulai dari bahan baku hingga produk akhir. Setiap daun teh dipilih secara selektif, setiap susu dipertimbangkan dengan cermat, dan setiap boba pearl dibuat dengan presisi untuk mencapai tekstur yang sempurna. Kami terus-menerus bereksperimen dengan kombinasi rasa baru dan unik, menciptakan resep-resep orisinal yang tidak akan Anda temukan di tempat lain.</p>
-                    <p data-aos="fade-left" data-aos-delay="500">Kami berdedikasi untuk memberikan pengalaman terbaik kepada setiap pelanggan. Setiap gelas boba yang kami sajikan adalah bukti dari passion dan kerja keras kami. Kami ingin Boba Lab menjadi laboratorium ide-ide brilian yang menghasilkan minuman lezat dan berkesan. Mari bergabung dengan kami dan rasakan sendiri perbedaannya—rasakan inovasi dalam setiap tegukan!</p>
+            </div>
+        </section>
+
+        <section class="about-story">
+            <div class="story-layout">
+                <div class="story-text" data-animate>
+                    <h2>Riset Rasa Tanpa Henti</h2>
+                    <p>Setiap resep di The Boba Lab melalui proses eksperimen panjang. Tim R&D kami mencoba ratusan kombinasi bahan untuk mendapatkan rasa yang seimbang dan tahan disajikan dalam kondisi cuaca tropis Indonesia.</p>
+                    <ul class="story-highlights">
+                        <li>
+                            <strong>Laboratorium In-House</strong>
+                            <span>Semua sirup dan topping dibuat sendiri untuk menjaga kualitas.</span>
+                        </li>
+                        <li>
+                            <strong>Supplier Terpercaya</strong>
+                            <span>Kami bekerja sama dengan petani teh dan susu lokal untuk memastikan pasokan terbaik.</span>
+                        </li>
+                        <li>
+                            <strong>Tim Barista Terlatih</strong>
+                            <span>Setiap anggota tim menjalani pelatihan intensif sebelum menyajikan menu kepada pelanggan.</span>
+                        </li>
+                    </ul>
                 </div>
+                <div class="story-visual" data-animate>
+                    <img src="Images/AboutUs.webp" alt="Tim The Boba Lab sedang menyiapkan minuman" loading="lazy">
+                    <div class="story-badge">
+                        <strong>20+ Varian</strong>
+                        <span>Rilis rasa baru setiap kuartal</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="timeline-section" id="timeline">
+            <div class="section-header" data-animate>
+                <p class="eyebrow">Timeline</p>
+                <h2>Perjalanan Inovasi Kami</h2>
+                <p>Dari pop-up kecil di kampus hingga membuka laboratorium rasa sendiri, berikut tonggak penting kami.</p>
+            </div>
+            <ol class="timeline">
+                <li data-animate style="--delay: .05s;">
+                    <span class="timeline-year">2019</span>
+                    <div class="timeline-card">
+                        <h3>Eksperimen Perdana</h3>
+                        <p>Memulai sebagai booth kecil dengan tiga menu utama dan fokus pada topping handmade.</p>
+                    </div>
+                </li>
+                <li data-animate style="--delay: .1s;">
+                    <span class="timeline-year">2020</span>
+                    <div class="timeline-card">
+                        <h3>Peluncuran Signature Series</h3>
+                        <p>Menambahkan varian Brown Sugar Milk dan Matcha Lover yang kini menjadi best seller.</p>
+                    </div>
+                </li>
+                <li data-animate style="--delay: .15s;">
+                    <span class="timeline-year">2022</span>
+                    <div class="timeline-card">
+                        <h3>Laboratorium Rasa</h3>
+                        <p>Membangun kitchen lab sendiri dan memperluas tim R&D untuk mengeksplor rasa regional.</p>
+                    </div>
+                </li>
+                <li data-animate style="--delay: .2s;">
+                    <span class="timeline-year">2024</span>
+                    <div class="timeline-card">
+                        <h3>Ekspansi Komunitas</h3>
+                        <p>Meluncurkan program kolaborasi bersama kreator kuliner dan menghadirkan kelas meracik boba.</p>
+                    </div>
+                </li>
+            </ol>
+        </section>
+
+        <section class="values-section">
+            <div class="section-header" data-animate>
+                <p class="eyebrow">Nilai Utama</p>
+                <h2>Budaya Kerja di The Boba Lab</h2>
+                <p>Kami memastikan seluruh tim bekerja dengan semangat eksplorasi dan kepedulian kepada pelanggan.</p>
+            </div>
+            <div class="values-grid">
+                <article class="value-card" data-animate style="--delay: .05s;">
+                    <h3>Rasa yang Jujur</h3>
+                    <p>Tidak ada perasa buatan yang berlebihan. Kami menjaga rasa tetap natural dan menonjolkan bahan utama.</p>
+                </article>
+                <article class="value-card" data-animate style="--delay: .1s;">
+                    <h3>Pelayanan Hangat</h3>
+                    <p>Kami percaya pengalaman pelanggan dimulai dari sapaan. Tim frontliner kami selalu siap membantu.</p>
+                </article>
+                <article class="value-card" data-animate style="--delay: .15s;">
+                    <h3>Eksperimen Berkelanjutan</h3>
+                    <p>Setiap ide baru diuji langsung dengan pelanggan komunitas kami sebelum dirilis resmi.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="team-invite">
+            <div class="team-content" data-animate>
+                <h2>Bergabung dalam Komunitas Riset Rasa</h2>
+                <p>Kami selalu mencari teman kolaborasi: dari petani lokal, food scientist, hingga konten kreator. Mari ciptakan inovasi rasa berikutnya bersama.</p>
+                <a class="btn ghost" href="contact.html">Hubungi Kami</a>
             </div>
         </section>
     </main>
@@ -82,10 +177,6 @@
         <p><i>Universitas Multimedia Nusantara</i></p>
     </footer>
 
-    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-    <script>
-        AOS.init();
-    </script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -27,7 +27,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="Images/Icon.ico">
-    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
 </head>
 
 <!-- Google tag (gtag.js) -->
@@ -40,7 +39,7 @@
   gtag('config', 'G-KFVXYQESC0');
 </script>
 
-<body>
+<body class="contact-page">
 
     <header>
         <div class="logo">
@@ -52,6 +51,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>
+                <li><a href="order.html">Order</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
@@ -59,37 +59,82 @@
         <div class="hamburger">☰</div>
     </header>
 
-    <main class="page-content">
-        <section class="contact-section">
-            <h2 data-aos="fade-down">Get In Touch</h2>
-            <p class="contact-slogan" data-aos="fade-down" data-aos-delay="100">We'd love to hear from you!</p>
-            
-            <div class="contact-info-form-container">
-                <div class="contact-info" data-aos="fade-right">
-                    <h3>Our Details</h3>
-                        <p><strong>Address:</strong> Jalan Boba No. 123, Kota Lab</p>
-                        <p><strong>Phone:</strong> <a href="tel:+6281234567890">+62 812-3456-7890</a></p>
-                        <p><strong>Instagram:</strong> <a href="https://www.instagram.com/thebobalab.id/" target="_blank">@thebobalab.id</a></p>
-                        <p><strong>Email:</strong> <a href="mailto:the.boba.lab.business@gmail.com">the.boba.lab.business@gmail.com</a></p>
-                        <p><strong>Youtube:</strong> <a href="https://www.youtube.com/channel/UC27TlRzDH-UD4I5ZlO7eDdw" target="_blank">@TheBobaLab</a></p>
-                        <p><strong>Facebook:</strong> <a href="https://www.facebook.com/your-page-name" target="_blank">thebobalab.com</a></p>
+    <main class="contact-main">
+        <section class="contact-hero">
+            <div class="contact-hero-content" data-animate>
+                <p class="eyebrow">Hubungi Kami</p>
+                <h1>Kami Siap Membantu Kapan Pun Kamu Ingin Boba</h1>
+                <p>Tim support kami tersedia untuk menjawab pertanyaan seputar menu, pemesanan dalam jumlah besar, hingga kerjasama bisnis.</p>
+                <div class="hero-actions">
+                    <a class="btn primary" href="tel:+6281234567890">Telepon Sekarang</a>
+                    <a class="btn ghost" href="mailto:the.boba.lab.business@gmail.com">Kirim Email</a>
                 </div>
+            </div>
+        </section>
 
-                <div class="contact-form" data-aos="fade-left">
-                    <h3>Send Us A Message</h3>
-                    <form action="#" method="post">
-                        <label for="name">Your Name</label>
-                        <input type="text" id="name" name="name" required>
+        <section class="contact-info-grid">
+            <article class="info-card" data-animate style="--delay: .05s;">
+                <h2>Kontak Langsung</h2>
+                <ul>
+                    <li><strong>Telepon:</strong> <a href="tel:+6281234567890">+62 812-3456-7890</a></li>
+                    <li><strong>Email:</strong> <a href="mailto:the.boba.lab.business@gmail.com">the.boba.lab.business@gmail.com</a></li>
+                    <li><strong>Instagram:</strong> <a href="https://www.instagram.com/thebobalab.id/" target="_blank" rel="noopener">@thebobalab.id</a></li>
+                    <li><strong>Youtube:</strong> <a href="https://www.youtube.com/channel/UC27TlRzDH-UD4I5ZlO7eDdw" target="_blank" rel="noopener">@TheBobaLab</a></li>
+                </ul>
+            </article>
+            <article class="info-card" data-animate style="--delay: .1s;">
+                <h2>Jam Operasional</h2>
+                <ul>
+                    <li><strong>Senin - Jumat:</strong> 09.00 - 21.00</li>
+                    <li><strong>Sabtu:</strong> 10.00 - 22.00</li>
+                    <li><strong>Minggu:</strong> 10.00 - 20.00</li>
+                    <li><strong>Alamat Lab:</strong> Jalan Boba No. 123, Kota Lab</li>
+                </ul>
+            </article>
+            <article class="info-card" data-animate style="--delay: .15s;">
+                <h2>Kerjasama & Event</h2>
+                <p>Kami menyediakan paket booth, catering boba, dan kolaborasi menu khusus. Kirimkan ide kamu dan tim kami akan segera menghubungi.</p>
+                <a class="text-link" href="mailto:the.boba.lab.business@gmail.com?subject=Kolaborasi%20Boba%20Lab">Ajukan proposal</a>
+            </article>
+        </section>
 
-                        <label for="email">Your Email</label>
-                        <input type="email" id="email" name="email" required>
-
-                        <label for="message">Your Message</label>
-                        <textarea id="message" name="message" rows="5" required></textarea>
-
-                        <button type="submit">Send Message</button>
-                    </form>
+        <section class="contact-form-section">
+            <div class="form-card" data-animate>
+                <h2>Kirim Pesan Langsung</h2>
+                <p>Isi formulir berikut dan kami akan membalas kurang dari 24 jam.</p>
+                <form action="#" method="post" class="contact-form">
+                    <div class="form-row">
+                        <label for="name">Nama Lengkap</label>
+                        <input type="text" id="name" name="name" placeholder="Nama kamu" required>
+                    </div>
+                    <div class="form-row">
+                        <label for="email">Alamat Email</label>
+                        <input type="email" id="email" name="email" placeholder="email@contoh.com" required>
+                    </div>
+                    <div class="form-row">
+                        <label for="topic">Topik</label>
+                        <select id="topic" name="topic">
+                            <option value="">Pilih topik</option>
+                            <option value="order">Pemesanan</option>
+                            <option value="event">Event & Catering</option>
+                            <option value="collaboration">Kolaborasi</option>
+                            <option value="other">Lainnya</option>
+                        </select>
+                    </div>
+                    <div class="form-row">
+                        <label for="message">Pesan</label>
+                        <textarea id="message" name="message" rows="5" placeholder="Tulis pesanmu..." required></textarea>
+                    </div>
+                    <button type="submit" class="btn primary">Kirim Pesan</button>
+                </form>
+            </div>
+            <div class="map-card" data-animate>
+                <h2>Temukan Kami</h2>
+                <p>Lab rasa kami berada di pusat kota sehingga mudah dijangkau. Kami juga menerima kunjungan komunitas dengan perjanjian.</p>
+                <div class="map-placeholder">
+                    <span>Jalan Boba No. 123<br>Kecamatan Flavor, Kota Lab 40512</span>
                 </div>
+                <a class="text-link" href="https://maps.google.com" target="_blank" rel="noopener">Lihat di Google Maps</a>
             </div>
         </section>
     </main>
@@ -100,10 +145,6 @@
         <p><i>Universitas Multimedia Nusantara</i></p>
     </footer>
 
-    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-    <script>
-        AOS.init();
-    </script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,7 +27,6 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/x-icon" href="Images/Icon.ico">
-    <link rel="stylesheet" href="https://unpkg.com/aos@next/dist/aos.css" />
 </head>
 
 <!-- Google tag (gtag.js) -->
@@ -40,7 +39,7 @@
   gtag('config', 'G-KFVXYQESC0');
 </script>
 
-<body>
+<body class="home-page">
 
     <header>
         <div class="logo">
@@ -52,6 +51,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Home</a></li>
+                <li><a href="order.html">Order</a></li>
                 <li><a href="about.html">About Us</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
@@ -59,97 +59,196 @@
         <div class="hamburger">☰</div>
     </header>
 
-    <main>
-        <section class="hero-slider">
-            <div class="slides">
-                <div class="slide active">
-                    <div class="overlay"></div>
-                    <img src="Images/Banner1.webp" alt="Gambar boba teh susu dengan boba pearls">
+    <main class="home-main">
+        <section class="hero-section">
+            <div class="hero-content" data-animate>
+                <p class="eyebrow">Lab Crafted Bubble Tea</p>
+                <h1>Temukan Laboratorium Rasa Boba Favoritmu</h1>
+                <p class="hero-copy">Setiap gelas kami diramu di dalam lab rasa untuk memastikan konsistensi dan pengalaman minum yang menakjubkan. Kamu bisa mengatur tingkat manis, topping, hingga tekstur boba sesuai selera.</p>
+                <div class="hero-actions">
+                    <a class="btn primary" href="order.html">Pesan Sekarang</a>
+                    <a class="btn ghost" href="#menu-preview">Lihat Signature Menu</a>
                 </div>
-                <div class="slide">
-                    <div class="overlay"></div>
-                    <img src="Images/Banner2.webp" alt="Gambar tangan sedang menuang boba ke dalam cangkir">
-                </div>
-                <div class="slide">
-                    <div class="overlay"></div>
-                    <img src="Images/Banner3.webp" alt="Gambar teh susu boba dengan gelembung-gelembung di atasnya">
+                <div class="hero-stats">
+                    <div class="stat">
+                        <strong>12+</strong>
+                        <span>Signature drinks</span>
+                    </div>
+                    <div class="stat">
+                        <strong>24 Jam</strong>
+                        <span>Diproses fresh harian</span>
+                    </div>
+                    <div class="stat">
+                        <strong>5K+</strong>
+                        <span>Pelanggan puas</span>
+                    </div>
                 </div>
             </div>
-            <div class="slide-text active"><h2>Explore Our <br> Signature Boba</h2></div>
-            <div class="slide-text"><h2>Freshly Made, <br> Just For You</h2></div>
-            <div class="slide-text"><h2>The Perfect Blend <br> Every Single Time</h2></div>
+            <div class="hero-visual" data-animate>
+                <div class="hero-slider-shell">
+                    <section class="hero-slider">
+                        <div class="slides">
+                            <div class="slide active">
+                                <div class="overlay"></div>
+                                <img src="Images/Banner1.webp" alt="Gambar boba teh susu dengan boba pearls">
+                            </div>
+                            <div class="slide">
+                                <div class="overlay"></div>
+                                <img src="Images/Banner2.webp" alt="Gambar tangan sedang menuang boba ke dalam cangkir">
+                            </div>
+                            <div class="slide">
+                                <div class="overlay"></div>
+                                <img src="Images/Banner3.webp" alt="Gambar teh susu boba dengan gelembung-gelembung di atasnya">
+                            </div>
+                        </div>
+                        <div class="slide-text active"><h2>Explore Our <br> Signature Boba</h2></div>
+                        <div class="slide-text"><h2>Freshly Made, <br> Just For You</h2></div>
+                        <div class="slide-text"><h2>The Perfect Blend <br> Every Single Time</h2></div>
 
-            <div class="dots-container">
-                <span class="dot active"></span>
-                <span class="dot"></span>
-                <span class="dot"></span>
+                        <div class="dots-container">
+                            <span class="dot active"></span>
+                            <span class="dot"></span>
+                            <span class="dot"></span>
+                        </div>
+                    </section>
+                </div>
+                <div class="hero-highlight">
+                    <h3>Signature Lab Series</h3>
+                    <p>Koleksi eksperimental kami yang digemari pelanggan setia untuk pengalaman boba kelas premium.</p>
+                    <a class="text-link" href="order.html">Lihat semua rasa</a>
+                </div>
             </div>
         </section>
 
-        <section class="menu-section">
-            <h2 data-aos="fade-up">Our Best-Selling Menus</h2>
-            <div class="menu-slider">
-                <div class="menu-track">
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="100">
-                        <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk">
+        <section class="brand-pillars">
+            <div class="section-header" data-animate>
+                <p class="eyebrow">Kenapa Memilih Boba Lab</p>
+                <h2>Setiap Detail Dibuat Dengan Standar Laboratorium</h2>
+                <p>Kami membawa pendekatan ilmiah pada proses pembuatan boba agar setiap minuman memiliki kualitas konsisten, rasa yang seimbang, dan tampilan yang menggoda.</p>
+            </div>
+            <div class="pillars-grid">
+                <article class="pillar-card" data-animate style="--delay: .05s;">
+                    <span class="pillar-icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><circle cx="24" cy="24" r="23" fill="#F7D6B9"/><path d="M16 24l5 5 11-11" stroke="#6A4E39" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </span>
+                    <h3>Bahan Pilihan</h3>
+                    <p>Susu segar, teh pilihan, dan boba homemade dimasak harian memastikan rasa yang selalu prima.</p>
+                </article>
+                <article class="pillar-card" data-animate style="--delay: .1s;">
+                    <span class="pillar-icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><rect x="5" y="5" width="38" height="38" rx="12" fill="#E8C8A3"/><path d="M16 32h16M24 16v16" stroke="#6A4E39" stroke-width="3" stroke-linecap="round"/></svg>
+                    </span>
+                    <h3>Kustomisasi Total</h3>
+                    <p>Pilih kadar gula, level es, hingga topping favorit. Kamu yang menentukan eksperimennya.</p>
+                </article>
+                <article class="pillar-card" data-animate style="--delay: .15s;">
+                    <span class="pillar-icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><path d="M24 4l14 8v16c0 8.837-6.268 16-14 16s-14-7.163-14-16V12l14-8z" fill="#F0D8C2"/><path d="M20 20l4 4 8-8" stroke="#6A4E39" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </span>
+                    <h3>Pengemasan Aman</h3>
+                    <p>Setiap gelas disegel rapat dan dikirim cepat agar tiba di tanganmu tanpa kompromi.</p>
+                </article>
+                <article class="pillar-card" data-animate style="--delay: .2s;">
+                    <span class="pillar-icon" aria-hidden="true">
+                        <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg"><circle cx="18" cy="30" r="10" fill="#EED5BC"/><circle cx="32" cy="18" r="10" fill="#F7D6B9"/><path d="M18 30l14-12" stroke="#6A4E39" stroke-width="3" stroke-linecap="round"/></svg>
+                    </span>
+                    <h3>Tim R&D Aktif</h3>
+                    <p>Menu baru bermunculan setiap musim dengan inspirasi rasa dari perjalanan kami ke Asia.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="signature-preview" id="menu-preview">
+            <div class="section-header" data-animate>
+                <p class="eyebrow">Signature Collection</p>
+                <h2>Favorit Sepanjang Tahun</h2>
+                <p>Empat menu terlaris yang selalu jadi pilihan pertama pelanggan kami. Semua bisa kamu pesan langsung dengan satu klik.</p>
+            </div>
+            <div class="preview-grid">
+                <article class="preview-card" data-animate style="--delay: .05s;">
+                    <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk" loading="lazy">
+                    <div class="preview-card-body">
                         <h3>Brown Sugar Milk</h3>
-                        <p>Classic and creamy milk tea with chewy brown sugar boba pearls.</p>
+                        <p>Perpaduan susu creamy dengan sirup brown sugar karamel yang kental.</p>
+                        <div class="preview-meta">
+                            <span class="price-tag">Rp 28.000</span>
+                            <a class="text-link" href="order.html">Pesan varian ini</a>
+                        </div>
                     </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="200">
-                        <img src="Images/Matcha.webp" alt="Matcha Lover">
+                </article>
+                <article class="preview-card" data-animate style="--delay: .1s;">
+                    <img src="Images/Matcha.webp" alt="Matcha Lover" loading="lazy">
+                    <div class="preview-card-body">
                         <h3>Matcha Lover</h3>
-                        <p>High-quality matcha tea with a rich, earthy flavor and tapioca pearls.</p>
+                        <p>Matcha Jepang premium dengan susu segar dan boba kenyal.</p>
+                        <div class="preview-meta">
+                            <span class="price-tag">Rp 30.000</span>
+                            <a class="text-link" href="order.html">Pesan varian ini</a>
+                        </div>
                     </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="300">
-                        <img src="Images/Strawberry.webp" alt="Strawberry Cream">
+                </article>
+                <article class="preview-card" data-animate style="--delay: .15s;">
+                    <img src="Images/Strawberry.webp" alt="Strawberry Cream" loading="lazy">
+                    <div class="preview-card-body">
                         <h3>Strawberry Cream</h3>
-                        <p>A sweet and fruity blend with fresh strawberry essence and a creamy finish.</p>
+                        <p>Puree stroberi segar dengan lapisan whipped cream lembut.</p>
+                        <div class="preview-meta">
+                            <span class="price-tag">Rp 29.000</span>
+                            <a class="text-link" href="order.html">Pesan varian ini</a>
+                        </div>
                     </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="400">
-                        <img src="Images/GreenMilk.webp" alt="Green Milk Tea">
+                </article>
+                <article class="preview-card" data-animate style="--delay: .2s;">
+                    <img src="Images/GreenMilk.webp" alt="Green Milk Tea" loading="lazy">
+                    <div class="preview-card-body">
                         <h3>Green Milk Tea</h3>
-                        <p>The rich cream of milk tea is coupled with a fragrant and delicate brew of green tea.</p>
+                        <p>Teh hijau wangi berpadu susu lembut, cocok untuk rasa klasik.</p>
+                        <div class="preview-meta">
+                            <span class="price-tag">Rp 25.000</span>
+                            <a class="text-link" href="order.html">Pesan varian ini</a>
+                        </div>
                     </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="500">
-                        <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk">
-                        <h3>Brown Sugar Milk</h3>
-                        <p>Classic and creamy milk tea with chewy brown sugar boba pearls.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="experience-section">
+            <div class="experience-layout">
+                <div class="experience-visual" data-animate>
+                    <img src="Images/AboutUs.webp" alt="Barista The Boba Lab sedang meracik minuman" loading="lazy">
+                    <div class="experience-badge">
+                        <strong>30 Menit</strong>
+                        <span>Rata-rata pengantaran</span>
                     </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="600">
-                        <img src="Images/Matcha.webp" alt="Matcha Lover">
-                        <h3>Matcha Lover</h3>
-                        <p>High-quality matcha tea with a rich, earthy flavor and tapioca pearls.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="700">
-                        <img src="Images/Strawberry.webp" alt="Strawberry Cream">
-                        <h3>Strawberry Cream</h3>
-                        <p>A sweet and fruity blend with fresh strawberry essence and a creamy finish.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="800">
-                        <img src="Images/GreenMilk.webp" alt="Green Milk Tea">
-                        <h3>Green Milk Tea</h3>
-                        <p>The rich cream of milk tea is coupled with a fragrant and delicate brew of green tea.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="900">
-                        <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk">
-                        <h3>Brown Sugar Milk</h3>
-                        <p>Classic and creamy milk tea with chewy brown sugar boba pearls.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="1000">
-                        <img src="Images/Matcha.webp" alt="Matcha Lover">
-                        <h3>Matcha Lover</h3>
-                        <p>High-quality matcha tea with a rich, earthy flavor and tapioca pearls.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="1100">
-                        <img src="Images/Strawberry.webp" alt="Strawberry Cream">
-                        <h3>Strawberry Cream</h3>
-                        <p>A sweet and fruity blend with fresh strawberry essence and a creamy finish.</p>
-                    </div>
-                    <div class="menu-item" data-aos="zoom-in" data-aos-delay="1200">
-                        <img src="Images/GreenMilk.webp" alt="Green Milk Tea">
-                        <h3>Green Milk Tea</h3>
-                        <p>The rich cream of milk tea is coupled with a fragrant and delicate brew of green tea.</p>
-                    </div>
+                </div>
+                <div class="experience-steps" data-animate>
+                    <p class="eyebrow">Cara Pesan</p>
+                    <h2>Pesan Dalam 3 Langkah Sederhana</h2>
+                    <ol class="step-list">
+                        <li>
+                            <h3>Pilih Menu</h3>
+                            <p>Telusuri signature dan seasonal series kami. Setiap menu dilengkapi deskripsi dan rekomendasi pairing.</p>
+                        </li>
+                        <li>
+                            <h3>Atur Eksperimenmu</h3>
+                            <p>Tentukan tingkat manis, level es, hingga topping favorit. Sistem kami langsung menghitung total secara real time.</p>
+                        </li>
+                        <li>
+                            <h3>Nikmati Tanpa Menunggu</h3>
+                            <p>Kami siapkan minumanmu dalam hitungan menit dan kirim melalui kurir andalan kami.</p>
+                        </li>
+                    </ol>
+                </div>
+            </div>
+        </section>
+
+        <section class="cta-banner">
+            <div class="cta-content" data-animate>
+                <h2>Siap Mengadakan Event atau Meeting?</h2>
+                <p>Kami menyediakan paket catering boba untuk kantor, pesta ulang tahun, hingga pop-up booth kampus. Hubungi kami dan tim akan bantu membuat racikan spesialmu.</p>
+                <div class="cta-actions">
+                    <a class="btn primary" href="order.html">Mulai Pesan</a>
+                    <a class="btn ghost" href="contact.html">Hubungi Tim Kami</a>
                 </div>
             </div>
         </section>
@@ -161,10 +260,6 @@
         <p><i>Universitas Multimedia Nusantara</i></p>
     </footer>
 
-    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-    <script>
-        AOS.init();
-    </script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/order.html
+++ b/order.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="id">
+<meta property="og:title" content="The Boba Lab" />
+<meta property="og:description" content="Di Boba Lab, setiap tegukan adalah sebuah eksperimen yang sempurna. Temukan kebahagiaan dalam setiap boba pearl kami." />
+<meta property="og:image" content="https://i.imgur.com/eKyJ5oZ.png" />
+<meta property="og:image:secure_url" content="https://i.imgur.com/eKyJ5oZ.png" />
+<meta property="og:image:type" content="image/png" />
+<meta property="og:image:width" content="1200" />
+<meta property="og:image:height" content="630" />
+<meta property="og:url" content="https://thebobalab.store/" />
+<meta property="og:type" content="website" />
+<meta property="og:site_name" content="The Boba Lab" />
+<meta name="twitter:card" content="summary_large_image" />
+<meta name="twitter:title" content="The Boba Lab" />
+<meta name="twitter:description" content="Di Boba Lab, setiap tegukan adalah sebuah eksperimen yang sempurna. Temukan kebahagiaan dalam setiap boba pearl kami." />
+<meta name="twitter:image" content="https://i.imgur.com/eKyJ5oZ.png" />
+<meta name="theme-color" content="#6A4E39" />
+<meta name="author" content="The Boba Lab Team" />
+<meta name="keywords" content="boba, bubble tea, milk tea, the boba lab, minuman kekinian" />
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Order - The Boba Lab</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/x-icon" href="Images/Icon.ico">
+</head>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-KFVXYQESC0"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-KFVXYQESC0');
+</script>
+
+<body class="order-page">
+
+    <header>
+        <div class="logo">
+            <a href="index.html" class="logo-link">
+                <img src="Images/Logo.webp" alt="Logo The Boba Lab">
+                <span>The Boba Lab</span>
+            </a>
+        </div>
+        <nav>
+            <ul>
+                <li><a href="index.html">Home</a></li>
+                <li><a href="order.html" class="active">Order</a></li>
+                <li><a href="about.html">About Us</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+        <div class="hamburger">☰</div>
+    </header>
+
+    <main class="order-main">
+        <section class="order-intro">
+            <div class="intro-text" style="--delay: .1s;">
+                <p class="eyebrow">Premium Crafted Drinks</p>
+                <h1>Pesan &amp; Nikmati Eksperimen Rasa Favoritmu</h1>
+                <p class="intro-copy">Setiap gelas boba kami diracik dengan bahan pilihan, dimasak langsung saat kamu memesan, dan dikemas dengan rapi agar tetap segar sampai di tanganmu. Pilih rasa favoritmu, atur tingkat kemanisan, dan kami akan menyiapkannya secepat mungkin.</p>
+                <div class="intro-highlights">
+                    <span class="highlight">Racikan segar harian</span>
+                    <span class="highlight">Boba kenyal handmade</span>
+                    <span class="highlight">Pengiriman instan</span>
+                </div>
+            </div>
+            <div class="intro-visual" style="--delay: .25s;">
+                <div class="visual-card primary">
+                    <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk" loading="lazy">
+                </div>
+                <div class="visual-card secondary">
+                    <img src="Images/Matcha.webp" alt="Matcha Lover" loading="lazy">
+                </div>
+                <div class="floating-badge">
+                    <strong>12+ Varian</strong>
+                    <span>Signature Series</span>
+                </div>
+            </div>
+        </section>
+
+        <div class="order-layout">
+            <section class="menu-panel">
+                <div class="menu-header">
+                    <h2>Menu Boba Kami</h2>
+                    <p>Pilih racikan favoritmu dan tambahkan ke keranjang. Semua minuman bisa disesuaikan sesuai selera.</p>
+                </div>
+                <div class="menu-toolbar">
+                    <div class="search-box">
+                        <input type="search" name="search" id="search" placeholder="Cari menu favoritmu..." aria-label="Cari menu">
+                    </div>
+                    <div class="menu-tags">
+                        <button type="button" class="tag active">Signature</button>
+                        <button type="button" class="tag">Seasonal</button>
+                        <button type="button" class="tag">Coffee Series</button>
+                        <button type="button" class="tag">Tea Based</button>
+                    </div>
+                </div>
+                <div class="menu-grid">
+                    <article class="menu-card" style="--delay: .35s;">
+                        <div class="menu-image">
+                            <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk">
+                            <span class="menu-badge bestseller">Best Seller</span>
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Brown Sugar Milk</h3>
+                                <span class="menu-volume">500 ml</span>
+                            </div>
+                            <p>Creamy fresh milk dengan sirup brown sugar yang dimasak perlahan hingga karamel sempurna.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 28.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .4s;">
+                        <div class="menu-image">
+                            <img src="Images/Matcha.webp" alt="Matcha Lover">
+                            <span class="menu-badge">New</span>
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Matcha Lover</h3>
+                                <span class="menu-volume">450 ml</span>
+                            </div>
+                            <p>Matcha Jepang premium dengan susu segar dan boba kenyal yang menambah tekstur.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 30.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .45s;">
+                        <div class="menu-image">
+                            <img src="Images/Strawberry.webp" alt="Strawberry Cream">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Strawberry Cream</h3>
+                                <span class="menu-volume">450 ml</span>
+                            </div>
+                            <p>Puree stroberi segar dan whipped cream lembut menciptakan sensasi manis menyegarkan.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 29.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .5s;">
+                        <div class="menu-image">
+                            <img src="Images/GreenMilk.webp" alt="Green Milk Tea">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Green Milk Tea</h3>
+                                <span class="menu-volume">500 ml</span>
+                            </div>
+                            <p>Teh hijau wangi dengan susu creamy yang cocok untuk kamu pencinta rasa klasik.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 25.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .55s;">
+                        <div class="menu-image">
+                            <img src="Images/BrownSugar.webp" alt="Caramel Coffee Boba">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Caramel Coffee Boba</h3>
+                                <span class="menu-volume">480 ml</span>
+                            </div>
+                            <p>Espresso bold dengan saus karamel dan sentuhan krim yang menyeimbangkan rasa pahit manis.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 32.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .6s;">
+                        <div class="menu-image">
+                            <img src="Images/Matcha.webp" alt="Houjicha Latte">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Houjicha Latte</h3>
+                                <span class="menu-volume">480 ml</span>
+                            </div>
+                            <p>Roasted tea khas Jepang dengan aroma smokey yang berpadu lembut dengan susu oat.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 31.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .65s;">
+                        <div class="menu-image">
+                            <img src="Images/Strawberry.webp" alt="Mango Sunrise">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Mango Sunrise</h3>
+                                <span class="menu-volume">450 ml</span>
+                            </div>
+                            <p>Lapisan mango puree, jasmine tea, dan popping boba tropical yang bikin mood naik.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 27.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .7s;">
+                        <div class="menu-image">
+                            <img src="Images/GreenMilk.webp" alt="Lychee Yakult Fizz">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Lychee Yakult Fizz</h3>
+                                <span class="menu-volume">400 ml</span>
+                            </div>
+                            <p>Kombinasi yakult, lychee segar, dan soda ringan untuk sensasi sparkling yang playful.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 26.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+
+                    <article class="menu-card" style="--delay: .75s;">
+                        <div class="menu-image">
+                            <img src="Images/BrownSugar.webp" alt="Taro Velvet">
+                        </div>
+                        <div class="menu-info">
+                            <div class="menu-info-header">
+                                <h3>Taro Velvet</h3>
+                                <span class="menu-volume">500 ml</span>
+                            </div>
+                            <p>Krim taro lembut dengan ekstra cheese foam gurih dan taburan crumble vanilla.</p>
+                            <div class="menu-meta">
+                                <span class="price">Rp 29.000</span>
+                                <button type="button" class="add-btn">Tambah</button>
+                            </div>
+                        </div>
+                    </article>
+                </div>
+            </section>
+
+            <aside class="cart-panel" aria-label="Ringkasan pesanan">
+                <div class="cart-header">
+                    <h2>Keranjang Kamu</h2>
+                    <span class="cart-count">2 item</span>
+                </div>
+                <div class="cart-body">
+                    <ul class="cart-items">
+                        <li class="cart-item">
+                            <div class="item-info">
+                                <h4>Brown Sugar Milk</h4>
+                                <span>Less Ice • Normal Sugar</span>
+                            </div>
+                            <div class="item-meta">
+                                <div class="quantity-control" aria-label="Atur jumlah Brown Sugar Milk">
+                                    <button type="button" aria-label="Kurangi">−</button>
+                                    <span class="quantity">2</span>
+                                    <button type="button" aria-label="Tambah">+</button>
+                                </div>
+                                <span class="item-price">Rp 56.000</span>
+                            </div>
+                        </li>
+                        <li class="cart-item">
+                            <div class="item-info">
+                                <h4>Matcha Lover</h4>
+                                <span>Less Sugar • Extra Boba</span>
+                            </div>
+                            <div class="item-meta">
+                                <div class="quantity-control" aria-label="Atur jumlah Matcha Lover">
+                                    <button type="button" aria-label="Kurangi">−</button>
+                                    <span class="quantity">1</span>
+                                    <button type="button" aria-label="Tambah">+</button>
+                                </div>
+                                <span class="item-price">Rp 30.000</span>
+                            </div>
+                        </li>
+                    </ul>
+                    <form class="promo-form">
+                        <label for="promo-code">Punya kode promo?</label>
+                        <div class="promo-input">
+                            <input type="text" id="promo-code" name="promo-code" placeholder="Masukkan kode">
+                            <button type="button">Gunakan</button>
+                        </div>
+                    </form>
+                </div>
+                <div class="cart-summary">
+                    <div class="summary-row">
+                        <span>Subtotal</span>
+                        <span>Rp 86.000</span>
+                    </div>
+                    <div class="summary-row">
+                        <span>Biaya Pengiriman</span>
+                        <span>Rp 8.000</span>
+                    </div>
+                    <div class="summary-row total">
+                        <span>Total</span>
+                        <span>Rp 94.000</span>
+                    </div>
+                    <button type="button" class="checkout-btn">Checkout Sekarang</button>
+                    <p class="checkout-note">* Pengiriman sekitar 20-30 menit. Kamu bisa memilih jadwal pickup atau delivery saat checkout.</p>
+                </div>
+            </aside>
+        </div>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 The Boba Lab. All rights reserved.</p>
+        <p><i>Made by Dhivie Chandra Rustandi - 00000089737</i></p>
+        <p><i>Universitas Multimedia Nusantara</i></p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/order.html
+++ b/order.html
@@ -95,15 +95,16 @@
                     <div class="search-box">
                         <input type="search" name="search" id="search" placeholder="Cari menu favoritmu..." aria-label="Cari menu">
                     </div>
-                    <div class="menu-tags">
-                        <button type="button" class="tag active">Signature</button>
-                        <button type="button" class="tag">Seasonal</button>
-                        <button type="button" class="tag">Coffee Series</button>
-                        <button type="button" class="tag">Tea Based</button>
+                    <div class="menu-tags" role="tablist">
+                        <button type="button" class="tag active" data-filter="all">Semua</button>
+                        <button type="button" class="tag" data-filter="signature">Signature</button>
+                        <button type="button" class="tag" data-filter="seasonal">Seasonal</button>
+                        <button type="button" class="tag" data-filter="coffee">Coffee Series</button>
+                        <button type="button" class="tag" data-filter="tea">Tea Based</button>
                     </div>
                 </div>
                 <div class="menu-grid">
-                    <article class="menu-card" style="--delay: .35s;">
+                    <article class="menu-card" data-id="brown-sugar" data-name="Brown Sugar Milk" data-price="28000" data-tags="signature,classic" style="--delay: .35s;">
                         <div class="menu-image">
                             <img src="Images/BrownSugar.webp" alt="Brown Sugar Milk">
                             <span class="menu-badge bestseller">Best Seller</span>
@@ -114,14 +115,41 @@
                                 <span class="menu-volume">500 ml</span>
                             </div>
                             <p>Creamy fresh milk dengan sirup brown sugar yang dimasak perlahan hingga karamel sempurna.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Extra Boba">Extra Boba</option>
+                                        <option value="Cheese Foam">Cheese Foam</option>
+                                        <option value="Grass Jelly">Grass Jelly</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 28.000</span>
+                                <span class="price" data-price-display>Rp 28.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .4s;">
+                    <article class="menu-card" data-id="matcha-lover" data-name="Matcha Lover" data-price="30000" data-tags="signature,tea" style="--delay: .4s;">
                         <div class="menu-image">
                             <img src="Images/Matcha.webp" alt="Matcha Lover">
                             <span class="menu-badge">New</span>
@@ -132,14 +160,41 @@
                                 <span class="menu-volume">450 ml</span>
                             </div>
                             <p>Matcha Jepang premium dengan susu segar dan boba kenyal yang menambah tekstur.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Extra Boba">Extra Boba</option>
+                                        <option value="Cheese Foam">Cheese Foam</option>
+                                        <option value="Red Bean">Red Bean</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 30.000</span>
+                                <span class="price" data-price-display>Rp 30.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .45s;">
+                    <article class="menu-card" data-id="strawberry-cream" data-name="Strawberry Cream" data-price="29000" data-tags="seasonal,fruit" style="--delay: .45s;">
                         <div class="menu-image">
                             <img src="Images/Strawberry.webp" alt="Strawberry Cream">
                         </div>
@@ -149,14 +204,41 @@
                                 <span class="menu-volume">450 ml</span>
                             </div>
                             <p>Puree stroberi segar dan whipped cream lembut menciptakan sensasi manis menyegarkan.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Cheese Foam">Cheese Foam</option>
+                                        <option value="Strawberry Jelly">Strawberry Jelly</option>
+                                        <option value="Crumble">Crumble</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 29.000</span>
+                                <span class="price" data-price-display>Rp 29.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .5s;">
+                    <article class="menu-card" data-id="green-milk-tea" data-name="Green Milk Tea" data-price="25000" data-tags="tea,classic" style="--delay: .5s;">
                         <div class="menu-image">
                             <img src="Images/GreenMilk.webp" alt="Green Milk Tea">
                         </div>
@@ -166,14 +248,41 @@
                                 <span class="menu-volume">500 ml</span>
                             </div>
                             <p>Teh hijau wangi dengan susu creamy yang cocok untuk kamu pencinta rasa klasik.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Crystal Boba">Crystal Boba</option>
+                                        <option value="Grass Jelly">Grass Jelly</option>
+                                        <option value="Pudding">Pudding</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 25.000</span>
+                                <span class="price" data-price-display>Rp 25.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .55s;">
+                    <article class="menu-card" data-id="caramel-coffee" data-name="Caramel Coffee Boba" data-price="32000" data-tags="coffee,signature" style="--delay: .55s;">
                         <div class="menu-image">
                             <img src="Images/BrownSugar.webp" alt="Caramel Coffee Boba">
                         </div>
@@ -183,14 +292,41 @@
                                 <span class="menu-volume">480 ml</span>
                             </div>
                             <p>Espresso bold dengan saus karamel dan sentuhan krim yang menyeimbangkan rasa pahit manis.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Coffee Jelly">Coffee Jelly</option>
+                                        <option value="Biscoff Crumble">Biscoff Crumble</option>
+                                        <option value="Sea Salt Foam">Sea Salt Foam</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 32.000</span>
+                                <span class="price" data-price-display>Rp 32.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .6s;">
+                    <article class="menu-card" data-id="houjicha-latte" data-name="Houjicha Latte" data-price="31000" data-tags="tea,seasonal" style="--delay: .6s;">
                         <div class="menu-image">
                             <img src="Images/Matcha.webp" alt="Houjicha Latte">
                         </div>
@@ -200,14 +336,41 @@
                                 <span class="menu-volume">480 ml</span>
                             </div>
                             <p>Roasted tea khas Jepang dengan aroma smokey yang berpadu lembut dengan susu oat.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Brown Sugar Pearls">Brown Sugar Pearls</option>
+                                        <option value="Soy Foam">Soy Foam</option>
+                                        <option value="Kinako Powder">Kinako Powder</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 31.000</span>
+                                <span class="price" data-price-display>Rp 31.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .65s;">
+                    <article class="menu-card" data-id="mango-sunrise" data-name="Mango Sunrise" data-price="27000" data-tags="seasonal,fruit" style="--delay: .65s;">
                         <div class="menu-image">
                             <img src="Images/Strawberry.webp" alt="Mango Sunrise">
                         </div>
@@ -217,14 +380,41 @@
                                 <span class="menu-volume">450 ml</span>
                             </div>
                             <p>Lapisan mango puree, jasmine tea, dan popping boba tropical yang bikin mood naik.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Popping Boba">Popping Boba</option>
+                                        <option value="Nata de Coco">Nata de Coco</option>
+                                        <option value="Aloe Vera">Aloe Vera</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 27.000</span>
+                                <span class="price" data-price-display>Rp 27.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .7s;">
+                    <article class="menu-card" data-id="lychee-yakult" data-name="Lychee Yakult Fizz" data-price="26000" data-tags="seasonal,tea" style="--delay: .7s;">
                         <div class="menu-image">
                             <img src="Images/GreenMilk.webp" alt="Lychee Yakult Fizz">
                         </div>
@@ -234,14 +424,41 @@
                                 <span class="menu-volume">400 ml</span>
                             </div>
                             <p>Kombinasi yakult, lychee segar, dan soda ringan untuk sensasi sparkling yang playful.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Lychee Jelly">Lychee Jelly</option>
+                                        <option value="Basil Seed">Basil Seed</option>
+                                        <option value="Citrus Peel">Citrus Peel</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 26.000</span>
+                                <span class="price" data-price-display>Rp 26.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
 
-                    <article class="menu-card" style="--delay: .75s;">
+                    <article class="menu-card" data-id="taro-velvet" data-name="Taro Velvet" data-price="29000" data-tags="signature,creamy" style="--delay: .75s;">
                         <div class="menu-image">
                             <img src="Images/BrownSugar.webp" alt="Taro Velvet">
                         </div>
@@ -251,73 +468,78 @@
                                 <span class="menu-volume">500 ml</span>
                             </div>
                             <p>Krim taro lembut dengan ekstra cheese foam gurih dan taburan crumble vanilla.</p>
+                            <div class="menu-options">
+                                <label>
+                                    <span>Level Es</span>
+                                    <select name="ice">
+                                        <option value="Normal Ice" selected>Normal Ice</option>
+                                        <option value="Less Ice">Less Ice</option>
+                                        <option value="No Ice">No Ice</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Kemanisan</span>
+                                    <select name="sweetness">
+                                        <option value="Normal Sugar" selected>Normal Sugar</option>
+                                        <option value="Less Sugar">Less Sugar</option>
+                                        <option value="Half Sugar">Half Sugar</option>
+                                    </select>
+                                </label>
+                                <label>
+                                    <span>Topping</span>
+                                    <select name="topping">
+                                        <option value="Tanpa Tambahan" selected>Tanpa Tambahan</option>
+                                        <option value="Cheese Foam">Cheese Foam</option>
+                                        <option value="Coconut Jelly">Coconut Jelly</option>
+                                        <option value="Oreo Crumble">Oreo Crumble</option>
+                                    </select>
+                                </label>
+                            </div>
                             <div class="menu-meta">
-                                <span class="price">Rp 29.000</span>
+                                <span class="price" data-price-display>Rp 29.000</span>
                                 <button type="button" class="add-btn">Tambah</button>
                             </div>
                         </div>
                     </article>
                 </div>
+                <p class="menu-empty" hidden>Tidak ada menu yang cocok dengan pencarianmu. Coba kategori atau kata kunci lain.</p>
             </section>
 
             <aside class="cart-panel" aria-label="Ringkasan pesanan">
                 <div class="cart-header">
                     <h2>Keranjang Kamu</h2>
-                    <span class="cart-count">2 item</span>
+                    <span class="cart-count">0 item</span>
                 </div>
                 <div class="cart-body">
-                    <ul class="cart-items">
-                        <li class="cart-item">
-                            <div class="item-info">
-                                <h4>Brown Sugar Milk</h4>
-                                <span>Less Ice • Normal Sugar</span>
-                            </div>
-                            <div class="item-meta">
-                                <div class="quantity-control" aria-label="Atur jumlah Brown Sugar Milk">
-                                    <button type="button" aria-label="Kurangi">−</button>
-                                    <span class="quantity">2</span>
-                                    <button type="button" aria-label="Tambah">+</button>
-                                </div>
-                                <span class="item-price">Rp 56.000</span>
-                            </div>
-                        </li>
-                        <li class="cart-item">
-                            <div class="item-info">
-                                <h4>Matcha Lover</h4>
-                                <span>Less Sugar • Extra Boba</span>
-                            </div>
-                            <div class="item-meta">
-                                <div class="quantity-control" aria-label="Atur jumlah Matcha Lover">
-                                    <button type="button" aria-label="Kurangi">−</button>
-                                    <span class="quantity">1</span>
-                                    <button type="button" aria-label="Tambah">+</button>
-                                </div>
-                                <span class="item-price">Rp 30.000</span>
-                            </div>
-                        </li>
-                    </ul>
-                    <form class="promo-form">
+                    <ul class="cart-items" aria-live="polite"></ul>
+                    <p class="empty-cart">Keranjang kamu masih kosong. Tambahkan menu favoritmu untuk mulai checkout.</p>
+                    <form class="promo-form" novalidate>
                         <label for="promo-code">Punya kode promo?</label>
                         <div class="promo-input">
                             <input type="text" id="promo-code" name="promo-code" placeholder="Masukkan kode">
-                            <button type="button">Gunakan</button>
+                            <button type="submit">Gunakan</button>
                         </div>
+                        <p class="promo-message" aria-live="polite"></p>
                     </form>
                 </div>
                 <div class="cart-summary">
                     <div class="summary-row">
                         <span>Subtotal</span>
-                        <span>Rp 86.000</span>
+                        <span data-subtotal>Rp 0</span>
+                    </div>
+                    <div class="summary-row discount" hidden>
+                        <span>Promo</span>
+                        <span data-discount>-Rp 0</span>
                     </div>
                     <div class="summary-row">
                         <span>Biaya Pengiriman</span>
-                        <span>Rp 8.000</span>
+                        <span data-shipping>Rp 0</span>
                     </div>
                     <div class="summary-row total">
                         <span>Total</span>
-                        <span>Rp 94.000</span>
+                        <span data-total>Rp 0</span>
                     </div>
-                    <button type="button" class="checkout-btn">Checkout Sekarang</button>
+                    <button type="button" class="checkout-btn" disabled>Keranjang masih kosong</button>
                     <p class="checkout-note">* Pengiriman sekitar 20-30 menit. Kamu bisa memilih jadwal pickup atau delivery saat checkout.</p>
                 </div>
             </aside>

--- a/script.js
+++ b/script.js
@@ -1,7 +1,9 @@
 document.addEventListener("DOMContentLoaded", function() {
-    let slides = document.querySelectorAll(".hero-slider .slide");
-    let texts = document.querySelectorAll(".hero-slider .slide-text");
-    let dots = document.querySelectorAll(".dots-container .dot");
+    const slides = document.querySelectorAll(".hero-slider .slide");
+    const texts = document.querySelectorAll(".hero-slider .slide-text");
+    const dots = document.querySelectorAll(".dots-container .dot");
+    const slidesContainer = document.querySelector(".hero-slider .slides");
+    const hasSlider = slides.length > 0 && slidesContainer;
     let currentIndex = 0;
     const slideDuration = 3000; // 3 detik
 
@@ -10,12 +12,20 @@ document.addEventListener("DOMContentLoaded", function() {
         texts.forEach(text => text.classList.remove("active"));
         dots.forEach(dot => dot.classList.remove("active"));
 
-        slides[index].classList.add("active");
-        texts[index].classList.add("active");
-        dots[index].classList.add("active");
+        if (slides[index]) {
+            slides[index].classList.add("active");
+        }
+        if (texts[index]) {
+            texts[index].classList.add("active");
+        }
+        if (dots[index]) {
+            dots[index].classList.add("active");
+        }
 
-        let offset = -index * 100;
-        document.querySelector(".slides").style.transform = `translateX(${offset}%)`;
+        if (slidesContainer) {
+            const offset = -index * 100;
+            slidesContainer.style.transform = `translateX(${offset}%)`;
+        }
     }
 
     function nextSlide() {
@@ -23,7 +33,10 @@ document.addEventListener("DOMContentLoaded", function() {
         showSlide(currentIndex);
     }
 
-    setInterval(nextSlide, slideDuration);
+    if (hasSlider) {
+        showSlide(currentIndex);
+        setInterval(nextSlide, slideDuration);
+    }
 
     // Hamburger toggle
     const hamburger = document.querySelector(".hamburger");

--- a/script.js
+++ b/script.js
@@ -127,7 +127,6 @@ function createCartItemElement(item) {
             </div>
             <span class="item-price">${formatCurrency(item.price * item.quantity)}</span>
         </div>
-        <button type="button" class="remove-item" data-action="remove" data-key="${item.key}" aria-label="Hapus ${item.name} dari keranjang">✕</button>
     `;
 
     return listItem;

--- a/script.js
+++ b/script.js
@@ -1,51 +1,473 @@
-document.addEventListener("DOMContentLoaded", function() {
-    const slides = document.querySelectorAll(".hero-slider .slide");
-    const texts = document.querySelectorAll(".hero-slider .slide-text");
-    const dots = document.querySelectorAll(".dots-container .dot");
-    const slidesContainer = document.querySelector(".hero-slider .slides");
-    const hasSlider = slides.length > 0 && slidesContainer;
+const CURRENCY_FORMATTER = new Intl.NumberFormat('id-ID', {
+    style: 'currency',
+    currency: 'IDR',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+});
+
+function formatCurrency(value) {
+    return CURRENCY_FORMATTER.format(value).replace(/\u00A0/g, ' ');
+}
+
+function initSlider() {
+    const slider = document.querySelector('.hero-slider');
+    if (!slider) {
+        return;
+    }
+
+    const slides = slider.querySelectorAll('.slide');
+    const texts = slider.querySelectorAll('.slide-text');
+    const dots = slider.querySelectorAll('.dots-container .dot');
+    const slidesContainer = slider.querySelector('.slides');
+
+    if (!slides.length || !slidesContainer) {
+        return;
+    }
+
     let currentIndex = 0;
-    const slideDuration = 3000; // 3 detik
+    const slideDuration = 4000;
+    let intervalId;
 
     function showSlide(index) {
-        slides.forEach(slide => slide.classList.remove("active"));
-        texts.forEach(text => text.classList.remove("active"));
-        dots.forEach(dot => dot.classList.remove("active"));
+        slides.forEach((slide, idx) => {
+            slide.classList.toggle('active', idx === index);
+        });
+        texts.forEach((text, idx) => {
+            text.classList.toggle('active', idx === index);
+        });
+        dots.forEach((dot, idx) => {
+            dot.classList.toggle('active', idx === index);
+        });
 
-        if (slides[index]) {
-            slides[index].classList.add("active");
-        }
-        if (texts[index]) {
-            texts[index].classList.add("active");
-        }
-        if (dots[index]) {
-            dots[index].classList.add("active");
-        }
+        slidesContainer.style.transform = `translateX(${-index * 100}%)`;
+    }
 
-        if (slidesContainer) {
-            const offset = -index * 100;
-            slidesContainer.style.transform = `translateX(${offset}%)`;
+    function stopAutoPlay() {
+        if (intervalId) {
+            clearInterval(intervalId);
+            intervalId = null;
         }
     }
 
-    function nextSlide() {
-        currentIndex = (currentIndex + 1) % slides.length;
+    function startAutoPlay() {
+        stopAutoPlay();
+        intervalId = window.setInterval(() => {
+            currentIndex = (currentIndex + 1) % slides.length;
+            showSlide(currentIndex);
+        }, slideDuration);
+    }
+
+    function goToSlide(index) {
+        currentIndex = index;
         showSlide(currentIndex);
+        startAutoPlay();
     }
 
-    if (hasSlider) {
-        showSlide(currentIndex);
-        setInterval(nextSlide, slideDuration);
+    if (dots.length) {
+        dots.forEach((dot, index) => {
+            dot.addEventListener('click', () => goToSlide(index));
+        });
     }
 
-    // Hamburger toggle
-    const hamburger = document.querySelector(".hamburger");
-    const nav = document.querySelector("nav");
+    slider.addEventListener('mouseenter', stopAutoPlay);
+    slider.addEventListener('mouseleave', startAutoPlay);
 
-    hamburger.addEventListener("click", function() {
-        nav.classList.toggle("active");
+    showSlide(currentIndex);
+    startAutoPlay();
+}
+
+function initHamburger() {
+    const hamburger = document.querySelector('.hamburger');
+    const nav = document.querySelector('header nav');
+
+    if (!hamburger || !nav) {
+        return;
+    }
+
+    hamburger.addEventListener('click', () => {
+        nav.classList.toggle('active');
+    });
+}
+
+function highlightActiveNav() {
+    const navLinks = document.querySelectorAll('header nav a[href]');
+
+    if (!navLinks.length) {
+        return;
+    }
+
+    const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+
+    navLinks.forEach(link => {
+        const href = link.getAttribute('href');
+        if (!href) {
+            return;
+        }
+
+        const normalizedHref = href.replace('./', '');
+        if (normalizedHref === currentPath) {
+            link.classList.add('active');
+        }
+    });
+}
+
+function createCartItemElement(item) {
+    const listItem = document.createElement('li');
+    listItem.className = 'cart-item';
+    listItem.innerHTML = `
+        <div class="item-info">
+            <h4>${item.name}</h4>
+            <span>${item.optionsLabel}</span>
+        </div>
+        <div class="item-meta">
+            <div class="quantity-control" aria-label="Atur jumlah ${item.name}">
+                <button type="button" class="qty-btn" data-action="decrease" data-key="${item.key}" aria-label="Kurangi ${item.name}">−</button>
+                <span class="quantity">${item.quantity}</span>
+                <button type="button" class="qty-btn" data-action="increase" data-key="${item.key}" aria-label="Tambah ${item.name}">+</button>
+            </div>
+            <span class="item-price">${formatCurrency(item.price * item.quantity)}</span>
+        </div>
+        <button type="button" class="remove-item" data-action="remove" data-key="${item.key}" aria-label="Hapus ${item.name} dari keranjang">✕</button>
+    `;
+
+    return listItem;
+}
+
+function buildOptionsLabel(options) {
+    const readable = [options.ice, options.sweetness];
+    if (options.topping && options.topping !== 'Tanpa Tambahan') {
+        readable.push(options.topping);
+    }
+
+    return readable.join(' • ');
+}
+
+function initOrderExperience() {
+    const menuCards = document.querySelectorAll('.menu-card');
+    const cartItemsContainer = document.querySelector('.cart-items');
+    const cartCountElement = document.querySelector('.cart-count');
+    const subtotalElement = document.querySelector('[data-subtotal]');
+    const shippingElement = document.querySelector('[data-shipping]');
+    const totalElement = document.querySelector('[data-total]');
+    const discountRow = document.querySelector('.summary-row.discount');
+    const discountValueElement = document.querySelector('[data-discount]');
+    const checkoutButton = document.querySelector('.checkout-btn');
+    const emptyCartMessage = document.querySelector('.empty-cart');
+    const menuEmptyMessage = document.querySelector('.menu-empty');
+    const searchInput = document.querySelector('#search');
+    const tagButtons = document.querySelectorAll('.menu-tags .tag');
+    const promoForm = document.querySelector('.promo-form');
+    const promoInput = document.querySelector('#promo-code');
+    const promoMessage = document.querySelector('.promo-message');
+
+    if (!menuCards.length || !cartItemsContainer || !cartCountElement || !subtotalElement || !shippingElement || !totalElement) {
+        return;
+    }
+
+    const SHIPPING_FEE = 8000;
+    const PROMO_CODES = {
+        BOBALAB10: {
+            type: 'percentage',
+            value: 0.1,
+            message: 'Yeay! Diskon 10% telah diterapkan.'
+        },
+        LABFREESHIP: {
+            type: 'shipping',
+            value: 1,
+            message: 'Gratis ongkir aktif untuk transaksi ini.'
+        }
+    };
+
+    const cart = [];
+    let activeFilter = 'all';
+    let appliedPromo = null;
+
+    menuCards.forEach(card => {
+        const priceElement = card.querySelector('[data-price-display]');
+        if (priceElement) {
+            const price = Number(card.dataset.price) || 0;
+            priceElement.textContent = formatCurrency(price);
+        }
     });
 
-    // Tambahkan kelas .loaded ke body setelah halaman dimuat
-    document.body.classList.add("loaded");
+    function getOptionsFromCard(card) {
+        const ice = card.querySelector('select[name="ice"]');
+        const sweetness = card.querySelector('select[name="sweetness"]');
+        const topping = card.querySelector('select[name="topping"]');
+
+        return {
+            ice: ice ? ice.value : 'Normal Ice',
+            sweetness: sweetness ? sweetness.value : 'Normal Sugar',
+            topping: topping ? topping.value : 'Tanpa Tambahan'
+        };
+    }
+
+    function buildKey(id, options) {
+        return [id, options.ice, options.sweetness, options.topping].join('|').toLowerCase();
+    }
+
+    function updateCartUI() {
+        const hasItems = cart.length > 0;
+        const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
+        let subtotal = 0;
+
+        cartItemsContainer.innerHTML = '';
+
+        if (hasItems) {
+            cart.forEach(item => {
+                subtotal += item.price * item.quantity;
+                cartItemsContainer.appendChild(createCartItemElement(item));
+            });
+        }
+
+        if (emptyCartMessage) {
+            emptyCartMessage.hidden = hasItems;
+        }
+
+        cartCountElement.textContent = `${totalItems} item`;
+
+        let discount = 0;
+        let shippingFee = hasItems ? SHIPPING_FEE : 0;
+
+        if (!hasItems) {
+            appliedPromo = null;
+            if (promoMessage) {
+                promoMessage.textContent = '';
+                promoMessage.classList.remove('error');
+            }
+            if (promoInput) {
+                promoInput.value = '';
+            }
+        }
+
+        if (appliedPromo && hasItems) {
+            if (appliedPromo.type === 'percentage') {
+                discount = Math.floor(subtotal * appliedPromo.value);
+            } else if (appliedPromo.type === 'shipping') {
+                shippingFee = 0;
+            }
+        }
+
+        if (discountRow && discountValueElement) {
+            if (discount > 0) {
+                discountRow.hidden = false;
+                discountValueElement.textContent = `-${formatCurrency(discount)}`;
+            } else {
+                discountRow.hidden = true;
+                discountValueElement.textContent = `-${formatCurrency(0)}`;
+            }
+        }
+
+        subtotalElement.textContent = formatCurrency(subtotal);
+        shippingElement.textContent = formatCurrency(shippingFee);
+
+        const total = Math.max(subtotal + shippingFee - discount, 0);
+        totalElement.textContent = formatCurrency(total);
+
+        if (checkoutButton) {
+            checkoutButton.disabled = !hasItems;
+            checkoutButton.textContent = hasItems ? 'Checkout Sekarang' : 'Keranjang masih kosong';
+        }
+    }
+
+    function addItemToCart(card) {
+        const id = card.dataset.id;
+        const name = card.dataset.name;
+        const price = Number(card.dataset.price) || 0;
+        const options = getOptionsFromCard(card);
+
+        if (!id || !name) {
+            return;
+        }
+
+        const key = buildKey(id, options);
+        const existing = cart.find(item => item.key === key);
+
+        if (existing) {
+            existing.quantity += 1;
+        } else {
+            cart.push({
+                id,
+                name,
+                price,
+                options,
+                optionsLabel: buildOptionsLabel(options),
+                quantity: 1,
+                key
+            });
+        }
+
+        updateCartUI();
+    }
+
+    function removeItem(key) {
+        const index = cart.findIndex(item => item.key === key);
+        if (index !== -1) {
+            cart.splice(index, 1);
+            updateCartUI();
+        }
+    }
+
+    function changeQuantity(key, delta) {
+        const item = cart.find(cartItem => cartItem.key === key);
+        if (!item) {
+            return;
+        }
+
+        item.quantity += delta;
+
+        if (item.quantity <= 0) {
+            removeItem(key);
+            return;
+        }
+
+        updateCartUI();
+    }
+
+    function applyFilter() {
+        const searchValue = searchInput ? searchInput.value.trim().toLowerCase() : '';
+        let visibleItems = 0;
+
+        menuCards.forEach(card => {
+            const name = card.dataset.name ? card.dataset.name.toLowerCase() : '';
+            const tags = card.dataset.tags ? card.dataset.tags.toLowerCase() : '';
+            const descriptionElement = card.querySelector('p');
+            const description = descriptionElement ? descriptionElement.textContent.toLowerCase() : '';
+
+            const matchesSearch = !searchValue || name.includes(searchValue) || description.includes(searchValue);
+            const matchesTag = activeFilter === 'all' || tags.split(',').map(tag => tag.trim()).includes(activeFilter);
+            const shouldShow = matchesSearch && matchesTag;
+
+            card.hidden = !shouldShow;
+
+            if (shouldShow) {
+                visibleItems += 1;
+            }
+        });
+
+        if (menuEmptyMessage) {
+            menuEmptyMessage.hidden = visibleItems > 0;
+        }
+    }
+
+    menuCards.forEach(card => {
+        const addButton = card.querySelector('.add-btn');
+        if (!addButton) {
+            return;
+        }
+
+        addButton.addEventListener('click', () => {
+            addButton.disabled = true;
+            addItemToCart(card);
+            addButton.classList.add('added');
+            addButton.textContent = 'Ditambahkan!';
+
+            window.setTimeout(() => {
+                addButton.disabled = false;
+                addButton.classList.remove('added');
+                addButton.textContent = 'Tambah';
+            }, 900);
+        });
+    });
+
+    if (cartItemsContainer) {
+        cartItemsContainer.addEventListener('click', event => {
+            const target = event.target;
+            if (!(target instanceof HTMLElement)) {
+                return;
+            }
+
+            const action = target.dataset.action;
+            const key = target.dataset.key;
+
+            if (!action || !key) {
+                return;
+            }
+
+            if (action === 'increase') {
+                changeQuantity(key, 1);
+            } else if (action === 'decrease') {
+                changeQuantity(key, -1);
+            } else if (action === 'remove') {
+                removeItem(key);
+            }
+        });
+    }
+
+    if (searchInput) {
+        searchInput.addEventListener('input', applyFilter);
+    }
+
+    if (tagButtons.length) {
+        tagButtons.forEach(button => {
+            button.addEventListener('click', () => {
+                tagButtons.forEach(btn => btn.classList.remove('active'));
+                button.classList.add('active');
+                activeFilter = button.dataset.filter || 'all';
+                applyFilter();
+            });
+        });
+    }
+
+    if (promoForm && promoInput && promoMessage) {
+        promoForm.addEventListener('submit', event => {
+            event.preventDefault();
+
+            const rawCode = promoInput.value.trim();
+
+            if (!rawCode) {
+                if (appliedPromo) {
+                    appliedPromo = null;
+                    promoMessage.textContent = 'Kode promo dibatalkan.';
+                    promoMessage.classList.remove('error');
+                    updateCartUI();
+                } else {
+                    promoMessage.textContent = 'Masukkan kode promo terlebih dahulu.';
+                    promoMessage.classList.add('error');
+                }
+                return;
+            }
+
+            const code = rawCode.toUpperCase();
+
+            if (!cart.length) {
+                promoMessage.textContent = 'Tambahkan menu ke keranjang sebelum menggunakan kode promo.';
+                promoMessage.classList.add('error');
+                return;
+            }
+
+            const promo = PROMO_CODES[code];
+
+            if (!promo) {
+                promoMessage.textContent = 'Kode promo tidak ditemukan. Coba periksa lagi ya!';
+                promoMessage.classList.add('error');
+                appliedPromo = null;
+                updateCartUI();
+                return;
+            }
+
+            appliedPromo = {
+                ...promo,
+                code
+            };
+            promoMessage.textContent = `${promo.message} (${code})`;
+            promoMessage.classList.remove('error');
+            updateCartUI();
+        });
+    }
+
+    applyFilter();
+    updateCartUI();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initSlider();
+    initHamburger();
+    highlightActiveNav();
+
+    if (document.body.classList.contains('order-page')) {
+        initOrderExperience();
+    }
+
+    document.body.classList.add('loaded');
 });

--- a/style.css
+++ b/style.css
@@ -17,6 +17,111 @@ body {
     position: relative;
 }
 
+img {
+    max-width: 100%;
+    display: block;
+}
+
+[data-animate] {
+    opacity: 0;
+    transform: translateY(32px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+    transition-delay: var(--delay, 0s);
+}
+
+body.loaded [data-animate] {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-radius: 999px;
+    font-weight: 600;
+    padding: 12px 26px;
+    text-decoration: none;
+    border: none;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease;
+}
+
+.btn.primary {
+    background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+    color: white;
+    box-shadow: 0 18px 32px rgba(106, 78, 57, 0.28);
+}
+
+.btn.primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 24px 38px rgba(106, 78, 57, 0.3);
+}
+
+.btn.ghost {
+    background: transparent;
+    color: var(--primary-color);
+    border: 2px solid rgba(106, 78, 57, 0.3);
+}
+
+.btn.ghost:hover {
+    color: white;
+    background: var(--primary-color);
+    border-color: transparent;
+}
+
+.text-link {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+    border-bottom: 1px solid rgba(106, 78, 57, 0.25);
+    padding-bottom: 3px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.text-link::after {
+    content: '→';
+    font-size: 0.9em;
+    transition: transform 0.3s ease;
+}
+
+.text-link:hover {
+    color: var(--accent-color);
+}
+
+.text-link:hover::after {
+    transform: translateX(4px);
+}
+
+.section-header {
+    max-width: 780px;
+    margin: 0 auto 48px;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.section-header h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.2rem, 4vw, 2.8rem);
+}
+
+.section-header p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
 &::-webkit-scrollbar-track {
     background-color: transparent;
 }
@@ -298,91 +403,799 @@ main.page-content {
     100% { transform: translateX(-50%); }
 }
 
-/* --- About & Contact Pages --- */
-.about-section, .contact-section {
-    background-color: white;
-    padding: 40px;
-    border-radius: 10px;
-    box-shadow: 0 2px 10px rgba(0,0,0,0.1);
-}
-
-.about-section h2, .contact-section h2 {
-    font-family: 'Playfair Display', serif;
-    text-align: center;
-    margin-bottom: 30px;
-}
-
-.about-container {
+/* --- Homepage --- */
+.home-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 60px 24px 100px;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    gap: 100px;
+}
+
+.hero-section {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 48px;
     align-items: center;
-    gap: 30px;
 }
 
-.about-image {
-    flex: 1;
-    min-width: 300px;
+.hero-content h1 {
+    margin: 0 0 18px;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.8rem, 5vw, 3.8rem);
+    line-height: 1.1;
 }
 
-.about-image img {
-    width: 100%;
-    border-radius: 8px;
-    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+.hero-copy {
+    margin: 0 0 24px;
+    color: rgba(51, 51, 51, 0.72);
 }
 
-.about-text {
-    flex: 2;
-}
-
-.contact-slogan {
-    text-align: center;
-    font-style: italic;
-    color: #888;
-    margin-bottom: 30px;
-}
-
-.contact-info-form-container {
+.hero-stats {
     display: flex;
     flex-wrap: wrap;
-    gap: 40px;
+    gap: 18px;
+    margin-top: 32px;
 }
 
-.contact-info, .contact-form {
-    flex: 1;
-    min-width: 280px;
+.stat {
+    background: white;
+    border-radius: 20px;
+    padding: 18px 24px;
+    min-width: 150px;
+    box-shadow: 0 18px 32px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
 }
 
-.contact-form form {
+.stat strong {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.8em;
+    color: var(--primary-color);
+}
+
+.stat span {
+    color: rgba(51, 51, 51, 0.6);
+    font-size: 0.85em;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.hero-visual {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.hero-slider-shell {
+    position: relative;
+    border-radius: 32px;
+    overflow: hidden;
+    box-shadow: 0 34px 56px rgba(106, 78, 57, 0.28);
+}
+
+body.home-page .hero-slider {
+    height: 460px;
+    border-radius: 32px;
+}
+
+body.home-page .slide-text {
+    font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.hero-highlight {
+    background: white;
+    border-radius: 24px;
+    padding: 26px 28px;
+    box-shadow: 0 18px 30px rgba(106, 78, 57, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.hero-highlight h3 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.hero-highlight p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.68);
+}
+
+.brand-pillars {
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+}
+
+.pillars-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.pillar-card {
+    background: white;
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: 0 20px 36px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.pillar-card h3 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.pillar-card p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.pillar-icon {
+    width: 68px;
+    height: 68px;
+    border-radius: 20px;
+    background: rgba(175, 139, 101, 0.15);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 12px 20px rgba(106, 78, 57, 0.14);
+}
+
+.pillar-icon svg {
+    width: 48px;
+    height: 48px;
+}
+
+.signature-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+}
+
+.preview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+}
+
+.preview-card {
+    background: white;
+    border-radius: 24px;
+    overflow: hidden;
+    box-shadow: 0 18px 32px rgba(106, 78, 57, 0.12);
     display: flex;
     flex-direction: column;
 }
 
-.contact-form label {
-    margin-bottom: 5px;
-    font-weight: 600;
+.preview-card img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
 }
 
-.contact-form input, .contact-form textarea {
-    padding: 12px;
-    margin-bottom: 20px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    font-family: inherit;
+.preview-card-body {
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    flex: 1;
 }
 
-.contact-form button {
-    background-color: var(--primary-color);
+.preview-card-body h3 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+    font-size: 1.3em;
+}
+
+.preview-card-body p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+    flex: 1;
+}
+
+.preview-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.price-tag {
+    background: rgba(175, 139, 101, 0.18);
+    color: var(--primary-color);
+    font-weight: 700;
+    padding: 8px 14px;
+    border-radius: 999px;
+    font-size: 0.9em;
+}
+
+.experience-section {
+    background: linear-gradient(135deg, rgba(247, 214, 185, 0.4), rgba(255, 255, 255, 0.9));
+    border-radius: 36px;
+    padding: 50px 40px;
+    box-shadow: 0 26px 44px rgba(106, 78, 57, 0.18);
+}
+
+.experience-layout {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.experience-visual {
+    position: relative;
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 24px 40px rgba(106, 78, 57, 0.2);
+}
+
+.experience-visual img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.experience-badge {
+    position: absolute;
+    bottom: 22px;
+    left: 22px;
+    background: white;
+    border-radius: 18px;
+    padding: 14px 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 18px 32px rgba(106, 78, 57, 0.2);
+}
+
+.experience-badge strong {
+    color: var(--primary-color);
+    font-size: 1.2em;
+}
+
+.experience-badge span {
+    font-size: 0.85em;
+    color: rgba(51, 51, 51, 0.65);
+}
+
+.experience-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.experience-steps h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.step-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    counter-reset: step;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.step-list li {
+    background: white;
+    border-radius: 22px;
+    padding: 24px 28px 24px 80px;
+    box-shadow: 0 16px 28px rgba(106, 78, 57, 0.12);
+    position: relative;
+}
+
+.step-list li::before {
+    content: counter(step, decimal-leading-zero);
+    counter-increment: step;
+    position: absolute;
+    left: 28px;
+    top: 24px;
+    font-weight: 700;
+    font-size: 1.1em;
+    color: var(--accent-color);
+}
+
+.step-list h3 {
+    margin: 0 0 6px;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.step-list p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.cta-banner {
+    background: var(--primary-color);
     color: white;
-    padding: 15px;
-    border: none;
-    border-radius: 5px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: background-color 0.3s;
+    border-radius: 36px;
+    padding: 60px 48px;
+    text-align: center;
+    box-shadow: 0 28px 48px rgba(106, 78, 57, 0.22);
 }
 
-.contact-form button:hover {
-    background-color: var(--accent-color);
+.cta-content {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-width: 680px;
+    margin: 0 auto;
+}
+
+.cta-content h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.2rem, 4vw, 2.8rem);
+}
+
+.cta-content p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.cta-actions {
+    display: flex;
+    justify-content: center;
+    gap: 16px;
+    flex-wrap: wrap;
+}
+
+.cta-banner .btn.ghost {
+    border-color: rgba(255, 255, 255, 0.6);
+    color: white;
+}
+
+.cta-banner .btn.ghost:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+/* --- About Page --- */
+.about-main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 60px 24px 100px;
+    display: flex;
+    flex-direction: column;
+    gap: 90px;
+}
+
+.page-hero {
+    background: linear-gradient(135deg, rgba(247, 214, 185, 0.55), rgba(255, 255, 255, 0.95));
+    border-radius: 40px;
+    padding: 90px 70px;
+    position: relative;
+    overflow: hidden;
+    box-shadow: 0 30px 50px rgba(106, 78, 57, 0.18);
+}
+
+.about-hero::after {
+    content: '';
+    position: absolute;
+    right: -80px;
+    top: -60px;
+    width: 320px;
+    height: 320px;
+    background: rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+}
+
+.hero-inner {
+    position: relative;
+    z-index: 1;
+    max-width: 640px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.hero-inner h1 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.6rem, 4.5vw, 3.4rem);
+}
+
+.hero-inner p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.72);
+}
+
+.about-story .story-layout {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+.story-text h2 {
+    margin: 0 0 12px;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+.story-text p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.75);
+}
+
+.story-highlights {
+    list-style: none;
+    margin: 28px 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.story-highlights li {
+    background: white;
+    border-radius: 20px;
+    padding: 18px 20px;
+    box-shadow: 0 12px 22px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.story-highlights strong {
+    color: var(--primary-color);
+}
+
+.story-highlights span {
+    color: rgba(51, 51, 51, 0.7);
+    font-size: 0.9em;
+}
+
+.story-visual {
+    position: relative;
+    border-radius: 28px;
+    overflow: hidden;
+    box-shadow: 0 26px 40px rgba(106, 78, 57, 0.18);
+}
+
+.story-visual img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.story-badge {
+    position: absolute;
+    bottom: 20px;
+    right: 20px;
+    background: white;
+    border-radius: 18px;
+    padding: 14px 18px;
+    box-shadow: 0 14px 26px rgba(106, 78, 57, 0.2);
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.story-badge strong {
+    color: var(--primary-color);
+    font-size: 1.1em;
+}
+
+.story-badge span {
+    color: rgba(51, 51, 51, 0.65);
+    font-size: 0.85em;
+}
+
+.timeline-section {
+    background: white;
+    border-radius: 32px;
+    padding: 50px 40px;
+    box-shadow: 0 24px 42px rgba(106, 78, 57, 0.16);
+}
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    position: relative;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 32px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(175, 139, 101, 0.25);
+}
+
+.timeline li {
+    position: relative;
+    padding-left: 96px;
+}
+
+.timeline-year {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 64px;
+    height: 64px;
+    border-radius: 18px;
+    background: rgba(175, 139, 101, 0.15);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: var(--primary-color);
+    font-size: 1.1em;
+    box-shadow: 0 12px 20px rgba(106, 78, 57, 0.12);
+}
+
+.timeline-card {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 24px;
+    padding: 20px 24px;
+    box-shadow: 0 14px 26px rgba(106, 78, 57, 0.12);
+}
+
+.timeline-card h3 {
+    margin: 0 0 6px;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.timeline-card p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.68);
+}
+
+.values-section {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+}
+
+.values-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 24px;
+}
+
+.value-card {
+    background: white;
+    border-radius: 24px;
+    padding: 26px;
+    box-shadow: 0 16px 28px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.value-card h3 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.value-card p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.team-invite {
+    background: linear-gradient(135deg, rgba(106, 78, 57, 0.9), rgba(175, 139, 101, 0.85));
+    color: white;
+    border-radius: 32px;
+    padding: 60px 50px;
+    text-align: center;
+    box-shadow: 0 28px 48px rgba(106, 78, 57, 0.22);
+}
+
+.team-content {
+    max-width: 640px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.team-content h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.1rem, 4vw, 2.8rem);
+}
+
+.team-content p {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.team-content .btn.ghost {
+    border-color: rgba(255, 255, 255, 0.6);
+    color: white;
+    align-self: center;
+}
+
+.team-content .btn.ghost:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+/* --- Contact Page --- */
+.contact-main {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 60px 24px 100px;
+    display: flex;
+    flex-direction: column;
+    gap: 80px;
+}
+
+.contact-hero {
+    background: white;
+    border-radius: 40px;
+    padding: 80px 70px;
+    box-shadow: 0 28px 48px rgba(106, 78, 57, 0.16);
+}
+
+.contact-hero-content {
+    max-width: 620px;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.contact-info-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 24px;
+}
+
+.info-card {
+    background: white;
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: 0 16px 28px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.info-card h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.info-card ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.info-card li {
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.info-card a {
+    color: var(--primary-color);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.info-card a:hover {
+    color: var(--accent-color);
+}
+
+.contact-form-section {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 32px;
+    align-items: stretch;
+}
+
+.form-card,
+.map-card {
+    background: white;
+    border-radius: 28px;
+    padding: 32px;
+    box-shadow: 0 20px 36px rgba(106, 78, 57, 0.14);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.form-card h2,
+.map-card h2 {
+    margin: 0;
+    font-family: 'Playfair Display', serif;
+    color: var(--primary-color);
+}
+
+.form-card p,
+.map-card p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.contact-form {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.contact-form .form-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.contact-form label {
+    font-weight: 600;
+}
+
+.contact-form input,
+.contact-form select,
+.contact-form textarea {
+    padding: 14px 16px;
+    border: 1px solid rgba(106, 78, 57, 0.25);
+    border-radius: 14px;
+    font-family: inherit;
+    font-size: 1em;
+    background: #fff;
+    transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+.contact-form input:focus,
+.contact-form select:focus,
+.contact-form textarea:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(175, 139, 101, 0.2);
+}
+
+.contact-form textarea {
+    resize: vertical;
+    min-height: 140px;
+}
+
+.contact-form .btn.primary {
+    align-self: flex-start;
+}
+
+.map-placeholder {
+    flex: 1;
+    border-radius: 22px;
+    background: linear-gradient(135deg, rgba(247, 214, 185, 0.4), rgba(175, 139, 101, 0.35));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 32px;
+    font-weight: 600;
+    color: var(--primary-color);
+    box-shadow: inset 0 0 0 1px rgba(106, 78, 57, 0.15);
+}
+
+.map-card .text-link::after {
+    content: '↗';
 }
 
 /* --- Order Page --- */
@@ -706,6 +1519,37 @@ body.order-page .menu-info p {
     font-size: 0.95em;
 }
 
+body.order-page .menu-options {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 10px;
+}
+
+body.order-page .menu-options label {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    font-size: 0.8em;
+    font-weight: 600;
+    color: rgba(51, 51, 51, 0.65);
+}
+
+body.order-page .menu-options select {
+    border: 1px solid rgba(106, 78, 57, 0.2);
+    border-radius: 12px;
+    padding: 10px 12px;
+    font-family: inherit;
+    font-size: 0.9em;
+    background-color: #fff;
+    transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.order-page .menu-options select:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 3px rgba(175, 139, 101, 0.18);
+}
+
 body.order-page .menu-meta {
     display: flex;
     justify-content: space-between;
@@ -733,6 +1577,16 @@ body.order-page .add-btn {
 body.order-page .add-btn:hover {
     transform: translateY(-2px);
     box-shadow: 0 12px 20px rgba(106, 78, 57, 0.25);
+}
+
+body.order-page .add-btn:disabled {
+    cursor: not-allowed;
+    opacity: 0.85;
+}
+
+body.order-page .add-btn.added {
+    background: linear-gradient(135deg, #2f9e44, #22863a);
+    box-shadow: 0 14px 24px rgba(47, 158, 68, 0.3);
 }
 
 .cart-panel {
@@ -793,11 +1647,30 @@ body.loaded.order-page .cart-panel {
     gap: 12px;
     padding-bottom: 18px;
     border-bottom: 1px dashed rgba(106, 78, 57, 0.18);
+    position: relative;
+    padding-right: 34px;
 }
 
 .cart-item:last-child {
     border-bottom: none;
     padding-bottom: 0;
+}
+
+.remove-item {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border: none;
+    background: transparent;
+    color: rgba(51, 51, 51, 0.35);
+    cursor: pointer;
+    font-size: 1rem;
+    transition: color 0.3s ease, transform 0.3s ease;
+}
+
+.remove-item:hover {
+    color: var(--primary-color);
+    transform: scale(1.1);
 }
 
 .item-info h4 {
@@ -901,6 +1774,42 @@ body.loaded.order-page .cart-panel {
     background: var(--accent-color);
 }
 
+.empty-cart {
+    margin: 0;
+    padding: 18px 20px;
+    background: rgba(175, 139, 101, 0.08);
+    border-radius: 18px;
+    font-size: 0.9em;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.empty-cart[hidden] {
+    display: none;
+}
+
+.menu-empty {
+    margin: 26px 0 0;
+    padding: 18px 20px;
+    border-radius: 18px;
+    background: rgba(175, 139, 101, 0.12);
+    color: rgba(51, 51, 51, 0.75);
+    font-weight: 600;
+}
+
+.menu-empty[hidden] {
+    display: none;
+}
+
+.promo-message {
+    margin: 0;
+    font-size: 0.85em;
+    color: var(--primary-color);
+}
+
+.promo-message.error {
+    color: #b3261e;
+}
+
 .cart-summary {
     display: flex;
     flex-direction: column;
@@ -940,6 +1849,13 @@ body.loaded.order-page .cart-panel {
     box-shadow: 0 22px 32px rgba(106, 78, 57, 0.3);
 }
 
+.checkout-btn:disabled {
+    background: rgba(175, 139, 101, 0.4);
+    box-shadow: none;
+    cursor: not-allowed;
+    transform: none;
+}
+
 .checkout-note {
     margin: 0;
     font-size: 0.8em;
@@ -958,6 +1874,51 @@ footer {
 
 /* --- Responsive Design --- */
 @media (max-width: 1024px) {
+    .home-main,
+    .about-main,
+    .contact-main {
+        padding: 50px 20px 80px;
+        gap: 70px;
+    }
+
+    .hero-section {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .hero-visual {
+        order: -1;
+    }
+
+    .hero-stats {
+        justify-content: center;
+    }
+
+    .experience-layout,
+    .about-story .story-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .experience-steps {
+        text-align: center;
+    }
+
+    .step-list li {
+        padding-left: 60px;
+    }
+
+    .step-list li::before {
+        left: 24px;
+    }
+
+    .page-hero {
+        padding: 70px 48px;
+    }
+
+    .contact-hero {
+        padding: 60px 40px;
+    }
+
     .order-intro {
         grid-template-columns: 1fr;
         text-align: center;
@@ -1029,6 +1990,80 @@ footer {
         display: block;
     }
 
+    .hero-section,
+    .experience-layout {
+        gap: 32px;
+    }
+
+    .hero-content h1 {
+        font-size: clamp(2.2rem, 7vw, 3rem);
+    }
+
+    body.home-page .hero-slider {
+        height: 380px;
+    }
+
+    .hero-highlight {
+        text-align: center;
+    }
+
+    .pillars-grid,
+    .preview-grid,
+    .values-grid,
+    .contact-info-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .experience-section {
+        padding: 40px 28px;
+    }
+
+    .experience-badge {
+        left: 16px;
+        bottom: 16px;
+    }
+
+    .page-hero {
+        padding: 60px 36px;
+        text-align: center;
+    }
+
+    .hero-inner {
+        align-items: center;
+    }
+
+    .timeline::before {
+        left: 20px;
+    }
+
+    .timeline li {
+        padding-left: 76px;
+    }
+
+    .timeline-year {
+        width: 56px;
+        height: 56px;
+    }
+
+    .team-invite {
+        padding: 50px 30px;
+    }
+
+    .contact-form-section {
+        grid-template-columns: 1fr;
+    }
+
+    .info-card,
+    .form-card,
+    .map-card {
+        text-align: center;
+        padding: 28px 24px;
+    }
+
+    .contact-form .btn.primary {
+        width: 100%;
+    }
+
     .order-main {
         padding: 30px 20px 60px;
         gap: 40px;
@@ -1074,41 +2109,51 @@ footer {
         width: 100%;
     }
 
-    .hero-slider, .slide {
-        height: 300px;
+    body.home-page .hero-slider {
+        height: 340px;
     }
 
-    .slide-text h2 {
-        font-size: clamp(1em, 3vw, 2em);
+    body.home-page .slide-text h2 {
+        font-size: clamp(1.4rem, 5vw, 2.2rem);
     }
 
-    .menu-track {
-        animation: none;
-        overflow-x: auto;
-        scroll-snap-type: x mandatory;
+    .hero-stats {
+        gap: 14px;
     }
 
-    .menu-item {
-        flex: 0 0 20%;
-        margin: 0 10px;
-        scroll-snap-align: center;
+    .stat {
+        width: 100%;
+        align-items: center;
     }
 
-    .about-container {
-        flex-direction: column;
+    .story-highlights li {
+        padding: 16px 18px;
     }
 
-    .about-text, .contact-info {
-        text-align: center;
+    .story-badge {
+        right: 12px;
+        bottom: 12px;
     }
 
-    .contact-info-form-container {
-        flex-direction: column;
-        gap: 20px;
+    .timeline::before {
+        left: 18px;
     }
 
-    .contact-info, .contact-form {
-        min-width: unset;
+    .timeline li {
+        padding-left: 68px;
+    }
+
+    .contact-hero-content,
+    .hero-content {
+        align-items: center;
+    }
+
+    .hero-actions {
+        justify-content: center;
+    }
+
+    .map-placeholder {
+        padding: 26px;
     }
 }
 
@@ -1120,6 +2165,75 @@ footer {
     nav li a {
         padding: 8px 10px;
         font-size: 0.9em;
+    }
+
+    .btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .hero-copy {
+        font-size: 0.95em;
+    }
+
+    .hero-stats {
+        gap: 12px;
+    }
+
+    body.home-page .hero-slider {
+        height: 300px;
+    }
+
+    .pillars-grid,
+    .preview-grid {
+        gap: 18px;
+    }
+
+    .preview-card img {
+        height: 200px;
+    }
+
+    .experience-section {
+        padding: 32px 20px;
+    }
+
+    .page-hero {
+        padding: 50px 24px;
+    }
+
+    .story-highlights li {
+        align-items: center;
+        text-align: center;
+    }
+
+    .story-badge {
+        position: static;
+        margin-top: 18px;
+        align-self: center;
+    }
+
+    .timeline li {
+        padding-left: 60px;
+    }
+
+    .timeline-year {
+        width: 50px;
+        height: 50px;
+        font-size: 1em;
+    }
+
+    .contact-hero {
+        padding: 45px 20px;
+    }
+
+    .info-card,
+    .form-card,
+    .map-card {
+        padding: 24px;
+    }
+
+    .map-placeholder {
+        padding: 20px;
     }
 
     .order-main {

--- a/style.css
+++ b/style.css
@@ -282,6 +282,10 @@ main.page-content {
     transition: opacity 0.5s ease-in-out;
 }
 
+.slide-text h2 {
+    font-size: 3rem;
+}
+
 .slide-text.active {
     opacity: 1;
 }
@@ -430,6 +434,7 @@ main.page-content {
 .hero-copy {
     margin: 0 0 24px;
     color: rgba(51, 51, 51, 0.72);
+    text-align: justify;
 }
 
 .hero-stats {
@@ -532,6 +537,7 @@ body.home-page .slide-text {
 .pillar-card p {
     margin: 0;
     color: rgba(51, 51, 51, 0.7);
+    text-align: justify;
 }
 
 .pillar-icon {
@@ -596,6 +602,7 @@ body.home-page .slide-text {
     margin: 0;
     color: rgba(51, 51, 51, 0.7);
     flex: 1;
+    text-align: justify;
 }
 
 .preview-meta {
@@ -612,6 +619,7 @@ body.home-page .slide-text {
     padding: 8px 14px;
     border-radius: 999px;
     font-size: 0.9em;
+    width: 100px;
 }
 
 .experience-section {
@@ -714,6 +722,7 @@ body.home-page .slide-text {
 .step-list p {
     margin: 0;
     color: rgba(51, 51, 51, 0.7);
+    text-align: justify;
 }
 
 .cta-banner {
@@ -808,6 +817,7 @@ body.home-page .slide-text {
 .hero-inner p {
     margin: 0;
     color: rgba(51, 51, 51, 0.72);
+    text-align: justify;
 }
 
 .about-story .story-layout {
@@ -826,6 +836,7 @@ body.home-page .slide-text {
 .story-text p {
     margin: 0;
     color: rgba(51, 51, 51, 0.75);
+    text-align: justify;
 }
 
 .story-highlights {
@@ -990,6 +1001,7 @@ body.home-page .slide-text {
 .value-card p {
     margin: 0;
     color: rgba(51, 51, 51, 0.7);
+    text-align: justify;
 }
 
 .team-invite {
@@ -1099,6 +1111,10 @@ body.home-page .slide-text {
     color: var(--accent-color);
 }
 
+.info-card p {
+    text-align: justify;
+}
+
 .contact-form-section {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
@@ -1128,6 +1144,7 @@ body.home-page .slide-text {
 .map-card p {
     margin: 0;
     color: rgba(51, 51, 51, 0.7);
+    text-align: justify;
 }
 
 .contact-form {
@@ -1248,6 +1265,7 @@ body.loaded.order-page .intro-visual {
     color: rgba(51, 51, 51, 0.8);
     font-size: 1.05em;
     max-width: 540px;
+    text-align: justify;
 }
 
 .intro-highlights {
@@ -1487,6 +1505,7 @@ body.order-page .menu-info {
     flex-direction: column;
     gap: 14px;
     flex: 1;
+    padding-top: 10px;
 }
 
 body.order-page .menu-info-header {
@@ -1503,15 +1522,18 @@ body.order-page .menu-info-header h3 {
 }
 
 body.order-page .menu-volume {
-    font-size: 0.85em;
+    font-size: 0.8em;
     color: rgba(51, 51, 51, 0.55);
     font-weight: 600;
+    width: 60px;
+    padding-right: none;
 }
 
 body.order-page .menu-info p {
     margin: 0;
     color: rgba(51, 51, 51, 0.75);
     font-size: 0.95em;
+    text-align: justify;
 }
 
 body.order-page .menu-options {
@@ -1624,7 +1646,8 @@ body.loaded.order-page .cart-panel {
     padding: 6px 14px;
     border-radius: 999px;
     font-weight: 600;
-    font-size: 0.85em;
+    width: 5rem;
+    align-items: center;    
 }
 
 .cart-items {
@@ -1643,7 +1666,6 @@ body.loaded.order-page .cart-panel {
     padding-bottom: 18px;
     border-bottom: 1px dashed rgba(106, 78, 57, 0.18);
     position: relative;
-    padding-right: 34px;
 }
 
 .cart-item:last-child {
@@ -1651,7 +1673,7 @@ body.loaded.order-page .cart-panel {
     padding-bottom: 0;
 }
 
-.remove-item {
+/* .remove-item {
     position: absolute;
     top: 0;
     right: 0;
@@ -1661,12 +1683,12 @@ body.loaded.order-page .cart-panel {
     cursor: pointer;
     font-size: 1rem;
     transition: color 0.3s ease, transform 0.3s ease;
-}
+} */
 
-.remove-item:hover {
+/* .remove-item:hover {
     color: var(--primary-color);
     transform: scale(1.1);
-}
+} */
 
 .item-info h4 {
     margin: 0 0 4px;
@@ -1682,7 +1704,7 @@ body.loaded.order-page .cart-panel {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 16px;
+    gap: 10px;
 }
 
 .quantity-control {
@@ -1721,6 +1743,7 @@ body.loaded.order-page .cart-panel {
 .item-price {
     font-weight: 700;
     color: var(--primary-color);
+    font-size: 1rem;
 }
 
 .promo-form {
@@ -1747,6 +1770,7 @@ body.loaded.order-page .cart-panel {
     border-radius: 14px;
     border: 1px solid rgba(106, 78, 57, 0.2);
     font-family: inherit;
+    max-width: 95px;
 }
 
 .promo-input input:focus {
@@ -1776,6 +1800,7 @@ body.loaded.order-page .cart-panel {
     border-radius: 18px;
     font-size: 0.9em;
     color: rgba(51, 51, 51, 0.7);
+    text-align: justify;
 }
 
 .empty-cart[hidden] {
@@ -1856,6 +1881,7 @@ body.loaded.order-page .cart-panel {
     font-size: 0.8em;
     color: rgba(51, 51, 51, 0.6);
     line-height: 1.5;
+    text-align: justify;
 }
 
 /* --- Footer --- */
@@ -1947,6 +1973,11 @@ footer {
 
     .cart-panel {
         position: static;
+    }
+
+    .cart-count {
+        width: auto;
+        padding: 6px 12px;
     }
 }
 
@@ -2150,6 +2181,10 @@ footer {
     .map-placeholder {
         padding: 26px;
     }
+
+    .cart-count {
+        width: auto;
+    }
 }
 
 @media (max-width: 480px) {
@@ -2176,7 +2211,7 @@ footer {
     }
 
     body.home-page .hero-slider {
-        height: 300px;
+        height: 200px;
     }
 
     .pillars-grid,
@@ -2249,7 +2284,7 @@ footer {
     }
 
     body.order-page .menu-info {
-        padding: 0 18px 20px;
+        padding: 0px 18px 20px;
     }
 
     .cart-panel {

--- a/style.css
+++ b/style.css
@@ -476,11 +476,6 @@ main.page-content {
     box-shadow: 0 34px 56px rgba(106, 78, 57, 0.28);
 }
 
-body.home-page .hero-slider {
-    height: 460px;
-    border-radius: 32px;
-}
-
 body.home-page .slide-text {
     font-size: clamp(2rem, 4vw, 2.6rem);
 }

--- a/style.css
+++ b/style.css
@@ -103,6 +103,11 @@ nav li a:hover {
     background-color: var(--accent-color);
 }
 
+nav li a.active {
+    background-color: var(--accent-color);
+    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+}
+
 /* --- Hamburger Menu --- */
 .hamburger {
     display: none;
@@ -380,6 +385,568 @@ main.page-content {
     background-color: var(--accent-color);
 }
 
+/* --- Order Page --- */
+body.order-page {
+    background: linear-gradient(180deg, var(--bg-color) 0%, #f4e9df 100%);
+}
+
+.order-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+    display: flex;
+    flex-direction: column;
+    gap: 50px;
+}
+
+.order-intro {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 40px;
+    align-items: center;
+}
+
+body.order-page .intro-text,
+body.order-page .intro-visual {
+    opacity: 0;
+    transform: translateY(40px);
+    transition: transform 0.6s ease, opacity 0.6s ease;
+    transition-delay: var(--delay, 0s);
+}
+
+body.loaded.order-page .intro-text,
+body.loaded.order-page .intro-visual {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.eyebrow {
+    font-size: 0.75em;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--accent-color);
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.order-intro h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.2rem, 4vw, 3.2rem);
+    margin: 0 0 20px;
+}
+
+.intro-copy {
+    margin: 0 0 24px;
+    color: rgba(51, 51, 51, 0.8);
+    font-size: 1.05em;
+    max-width: 540px;
+}
+
+.intro-highlights {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+}
+
+.intro-highlights .highlight {
+    background: rgba(175, 139, 101, 0.12);
+    color: var(--primary-color);
+    padding: 10px 18px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.9em;
+}
+
+.intro-visual {
+    position: relative;
+    min-height: 320px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    padding: 30px 20px;
+}
+
+.intro-visual::before {
+    content: "";
+    position: absolute;
+    inset: 12% 12% 8% 8%;
+    background: linear-gradient(140deg, rgba(247, 214, 185, 0.9), rgba(175, 139, 101, 0.55));
+    border-radius: 32px;
+    filter: blur(0);
+    z-index: 0;
+}
+
+.visual-card {
+    position: relative;
+    border-radius: 28px;
+    backdrop-filter: blur(8px);
+    overflow: hidden;
+    box-shadow: 0 30px 45px rgba(106, 78, 57, 0.25);
+    z-index: 2;
+    background: rgba(255, 255, 255, 0.65);
+}
+
+.visual-card.primary {
+    width: min(320px, 75%);
+    padding: 36px 24px 24px;
+    transform: rotate(-4deg);
+}
+
+.visual-card.secondary {
+    position: absolute;
+    top: 40px;
+    right: 12%;
+    width: min(200px, 48%);
+    padding: 28px 18px 18px;
+    transform: rotate(8deg);
+    box-shadow: 0 20px 30px rgba(106, 78, 57, 0.18);
+    z-index: 1;
+    background: rgba(255, 255, 255, 0.55);
+}
+
+.visual-card img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+}
+
+.floating-badge {
+    position: absolute;
+    left: 8%;
+    bottom: 12%;
+    background: var(--primary-color);
+    color: white;
+    padding: 16px 20px;
+    border-radius: 18px;
+    display: inline-flex;
+    flex-direction: column;
+    gap: 4px;
+    box-shadow: 0 15px 25px rgba(106, 78, 57, 0.3);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.floating-badge strong {
+    font-size: 1.05em;
+}
+
+.floating-badge span {
+    font-size: 0.75em;
+    opacity: 0.85;
+}
+
+.order-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(280px, 1fr);
+    gap: 32px;
+    align-items: flex-start;
+}
+
+.menu-panel {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 24px;
+    padding: 32px 28px;
+    box-shadow: 0 20px 35px rgba(106, 78, 57, 0.18);
+    border: 1px solid rgba(106, 78, 57, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 28px;
+}
+
+body.order-page .menu-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2em;
+    margin: 0 0 12px;
+}
+
+body.order-page .menu-header p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+body.order-page .menu-toolbar {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+body.order-page .search-box input {
+    width: 100%;
+    padding: 14px 18px;
+    border: 1px solid rgba(106, 78, 57, 0.2);
+    border-radius: 14px;
+    font-family: inherit;
+    font-size: 0.95em;
+    transition: border 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.order-page .search-box input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+    box-shadow: 0 0 0 4px rgba(175, 139, 101, 0.25);
+}
+
+body.order-page .menu-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+body.order-page .menu-tags .tag {
+    background: rgba(175, 139, 101, 0.12);
+    color: var(--primary-color);
+    border: none;
+    border-radius: 999px;
+    padding: 9px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.3s ease, color 0.3s ease, transform 0.3s ease;
+}
+
+body.order-page .menu-tags .tag:hover,
+body.order-page .menu-tags .tag.active {
+    background: var(--primary-color);
+    color: white;
+    transform: translateY(-1px);
+}
+
+body.order-page .menu-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 24px;
+}
+
+body.order-page .menu-card {
+    background: white;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 12px 24px rgba(106, 78, 57, 0.12);
+    display: flex;
+    flex-direction: column;
+    transition: transform 0.6s ease, opacity 0.6s ease, box-shadow 0.3s ease;
+    opacity: 0;
+    transform: translateY(30px);
+    transition-delay: var(--delay, 0s);
+}
+
+body.loaded.order-page .menu-card {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+body.order-page .menu-card:hover {
+    box-shadow: 0 18px 32px rgba(106, 78, 57, 0.18);
+    transform: translateY(-4px);
+}
+
+body.order-page .menu-image {
+    position: relative;
+    display: grid;
+    place-items: center;
+    padding: 26px;
+    background: radial-gradient(circle at top, rgba(247, 214, 185, 0.65), rgba(175, 139, 101, 0.15));
+}
+
+body.order-page .menu-image img {
+    width: 80%;
+    height: auto;
+}
+
+body.order-page .menu-badge {
+    position: absolute;
+    top: 18px;
+    left: 18px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--primary-color);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-size: 0.75em;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    box-shadow: 0 10px 15px rgba(106, 78, 57, 0.15);
+}
+
+body.order-page .menu-badge.bestseller {
+    background: var(--primary-color);
+    color: #fff5e6;
+}
+
+body.order-page .menu-info {
+    padding: 0 22px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+    flex: 1;
+}
+
+body.order-page .menu-info-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 12px;
+}
+
+body.order-page .menu-info-header h3 {
+    margin: 0;
+    font-size: 1.15em;
+    color: var(--primary-color);
+}
+
+body.order-page .menu-volume {
+    font-size: 0.85em;
+    color: rgba(51, 51, 51, 0.55);
+    font-weight: 600;
+}
+
+body.order-page .menu-info p {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.75);
+    font-size: 0.95em;
+}
+
+body.order-page .menu-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: auto;
+}
+
+body.order-page .price {
+    font-weight: 700;
+    font-size: 1.1em;
+    color: var(--primary-color);
+}
+
+body.order-page .add-btn {
+    padding: 10px 18px;
+    background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+    color: white;
+    border: none;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+body.order-page .add-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 20px rgba(106, 78, 57, 0.25);
+}
+
+.cart-panel {
+    position: sticky;
+    top: 120px;
+    background: #ffffff;
+    border-radius: 24px;
+    padding: 28px;
+    box-shadow: 0 24px 35px rgba(106, 78, 57, 0.18);
+    border: 1px solid rgba(106, 78, 57, 0.1);
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+    opacity: 0;
+    transform: translateY(40px);
+    transition: transform 0.6s ease, opacity 0.6s ease;
+    transition-delay: 0.35s;
+}
+
+body.loaded.order-page .cart-panel {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.cart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.cart-header h2 {
+    font-family: 'Playfair Display', serif;
+    margin: 0;
+    font-size: 1.6em;
+}
+
+.cart-count {
+    background: rgba(175, 139, 101, 0.15);
+    color: var(--primary-color);
+    padding: 6px 14px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.85em;
+}
+
+.cart-items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.cart-item {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding-bottom: 18px;
+    border-bottom: 1px dashed rgba(106, 78, 57, 0.18);
+}
+
+.cart-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.item-info h4 {
+    margin: 0 0 4px;
+    font-size: 1.05em;
+}
+
+.item-info span {
+    font-size: 0.85em;
+    color: rgba(51, 51, 51, 0.6);
+}
+
+.item-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.quantity-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    background: rgba(175, 139, 101, 0.12);
+    padding: 6px 10px;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.quantity-control button {
+    width: 28px;
+    height: 28px;
+    border: none;
+    background: white;
+    border-radius: 50%;
+    cursor: pointer;
+    font-size: 1em;
+    line-height: 1;
+    color: var(--primary-color);
+    box-shadow: 0 6px 12px rgba(106, 78, 57, 0.18);
+}
+
+.quantity-control button:hover {
+    background: var(--primary-color);
+    color: white;
+}
+
+.quantity {
+    min-width: 18px;
+    text-align: center;
+}
+
+.item-price {
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.promo-form {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.promo-form label {
+    font-weight: 600;
+    font-size: 0.9em;
+    color: rgba(51, 51, 51, 0.7);
+}
+
+.promo-input {
+    display: flex;
+    gap: 10px;
+}
+
+.promo-input input {
+    flex: 1;
+    padding: 12px 16px;
+    border-radius: 14px;
+    border: 1px solid rgba(106, 78, 57, 0.2);
+    font-family: inherit;
+}
+
+.promo-input input:focus {
+    outline: none;
+    border-color: var(--primary-color);
+}
+
+.promo-input button {
+    padding: 12px 20px;
+    background: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+.promo-input button:hover {
+    background: var(--accent-color);
+}
+
+.cart-summary {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    border-top: 1px solid rgba(106, 78, 57, 0.12);
+    padding-top: 18px;
+}
+
+.summary-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.95em;
+}
+
+.summary-row.total {
+    font-size: 1.1em;
+    font-weight: 700;
+}
+
+.checkout-btn {
+    width: 100%;
+    padding: 14px 18px;
+    border: none;
+    border-radius: 16px;
+    font-weight: 600;
+    font-size: 1em;
+    background: linear-gradient(135deg, var(--primary-color), #d2a679);
+    color: white;
+    cursor: pointer;
+    box-shadow: 0 16px 28px rgba(106, 78, 57, 0.25);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.checkout-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 32px rgba(106, 78, 57, 0.3);
+}
+
+.checkout-note {
+    margin: 0;
+    font-size: 0.8em;
+    color: rgba(51, 51, 51, 0.6);
+    line-height: 1.5;
+}
+
 /* --- Footer --- */
 footer {
     text-align: center;
@@ -390,6 +957,43 @@ footer {
 }
 
 /* --- Responsive Design --- */
+@media (max-width: 1024px) {
+    .order-intro {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+
+    .intro-copy {
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .intro-visual {
+        max-width: 520px;
+        margin: 0 auto;
+    }
+
+    .visual-card.primary {
+        width: min(280px, 85%);
+    }
+
+    .visual-card.secondary {
+        right: 18%;
+    }
+
+    .floating-badge {
+        left: 18%;
+    }
+
+    .order-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .cart-panel {
+        position: static;
+    }
+}
+
 @media (max-width: 768px) {
     header {
         flex-direction: column;
@@ -423,6 +1027,51 @@ footer {
 
     .hamburger {
         display: block;
+    }
+
+    .order-main {
+        padding: 30px 20px 60px;
+        gap: 40px;
+    }
+
+    .intro-highlights {
+        justify-content: center;
+    }
+
+    .intro-visual {
+        padding: 24px 16px;
+    }
+
+    .floating-badge {
+        left: 12%;
+        bottom: 18%;
+    }
+
+    body.order-page .menu-panel {
+        padding: 26px 20px;
+    }
+
+    body.order-page .menu-grid {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+
+    body.order-page .item-meta {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 12px;
+    }
+
+    body.order-page .quantity-control {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    body.order-page .promo-input {
+        flex-direction: column;
+    }
+
+    body.order-page .promo-input button {
+        width: 100%;
     }
 
     .hero-slider, .slide {
@@ -473,6 +1122,36 @@ footer {
         font-size: 0.9em;
     }
 
+    .order-main {
+        padding: 24px 16px 50px;
+    }
+
+    .intro-highlights .highlight {
+        width: 100%;
+        text-align: center;
+    }
+
+    .visual-card.secondary {
+        right: 10%;
+    }
+
+    body.order-page .menu-grid {
+        grid-template-columns: 1fr;
+    }
+
+    body.order-page .menu-info {
+        padding: 0 18px 20px;
+    }
+
+    .cart-panel {
+        padding: 24px;
+    }
+
+    body.order-page .quantity-control button {
+        width: 26px;
+        height: 26px;
+    }
+
     .hero-slider, .slide {
         height: 250px;
     }
@@ -488,6 +1167,4 @@ footer {
     .about-section, .contact-section {
         padding: 20px;
     }
-
-
 }


### PR DESCRIPTION
## Summary
- add a dedicated order page with a menu grid, hero intro, and cart sidebar layout
- style the order experience with responsive grid, cart, and load-in transitions while highlighting the active nav item
- harden the shared script so the homepage slider logic only runs when the slider exists

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c8d1d22c50832c884e61ae22cebba6