### PR TITLE
Refine 404 page with minimal layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Halaman Tidak Ditemukan | The Boba Lab</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&family=Playfair+Display:wght@700&display=swap" rel="stylesheet">
+    <link rel="icon" type="image/x-icon" href="Images/Icon.ico">
+    <meta name="robots" content="noindex">
+</head>
+<body class="error-page">
+    <header class="error-header" role="banner">
+        <a href="index.html" class="error-brand" aria-label="Kembali ke beranda The Boba Lab">
+            <img src="Images/Logo.webp" alt="Logo The Boba Lab" class="error-logo" loading="lazy">
+            <span class="error-brand-text">
+                <span class="error-brand-name">The Boba Lab</span>
+                <span class="error-brand-tagline">Lab Crafted Bubble Tea</span>
+            </span>
+        </a>
+    </header>
+
+    <main class="error-main" role="main">
+        <section class="error-content" aria-labelledby="error-title">
+            <span class="error-eyebrow" aria-hidden="true">Kode 404</span>
+            <h1 id="error-title">Halaman Tidak Ditemukan</h1>
+            <p class="error-message">Kami belum menemukan eksperimen rasa yang kamu tuju, kemungkinan sudah dipindahkan atau tidak lagi tersedia.</p>
+            <p class="error-suggestion">Kembali ke laboratorium utama untuk melanjutkan penjelajahan menu boba kami.</p>
+            <div class="error-actions">
+                <a href="index.html" class="btn primary">Kembali ke Beranda</a>
+                <a href="contact.html" class="text-link">Hubungi tim The Boba Lab</a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="error-footer">
+        <p>© <span id="current-year"></span> The Boba Lab. Terus bereksperimen dengan rasa terbaik.</p>
+    </footer>
+
+    <script>
+        document.getElementById('current-year').textContent = new Date().getFullYear();
+    </script>
+</body>
+</html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -5,6 +5,7 @@ const OFFLINE_ASSETS = [
     './about.html',
     './contact.html',
     './order.html',
+    './404.html',
     './style.css',
     './script.js',
     './Images/AboutUs.webp',

--- a/style.css
+++ b/style.css
@@ -3263,3 +3263,171 @@ footer {
     }
 
 }
+/* 404 Error Page */
+body.error-page {
+    min-height: 100vh;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    background: linear-gradient(180deg, rgba(247, 214, 185, 0.28) 0%, rgba(253, 249, 246, 0) 42%), var(--bg-color);
+    color: var(--text-color);
+}
+
+.error-header,
+.error-footer {
+    width: min(960px, 92vw);
+    margin: 0 auto;
+}
+
+.error-header {
+    padding: clamp(28px, 5vw, 48px) 0 12px;
+    display: flex;
+    justify-content: center;
+}
+
+.error-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 14px;
+    text-decoration: none;
+    color: inherit;
+}
+
+.error-brand-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+}
+
+.error-brand-name {
+    font-family: 'Playfair Display', 'Times New Roman', serif;
+    font-size: 1.5rem;
+    letter-spacing: 0.5px;
+}
+
+.error-brand-tagline {
+    font-size: 0.9rem;
+    color: rgba(54, 36, 23, 0.7);
+}
+
+.error-logo {
+    width: 72px;
+    height: 72px;
+    border-radius: 20px;
+    box-shadow: 0 18px 45px rgba(106, 78, 57, 0.28);
+    object-fit: cover;
+}
+
+.error-main {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: clamp(24px, 8vw, 72px) 0;
+}
+
+.error-content {
+    position: relative;
+    width: min(640px, 92vw);
+    background: #fff;
+    border-radius: 32px;
+    padding: clamp(40px, 6vw, 72px);
+    box-shadow: 0 42px 120px rgba(34, 24, 17, 0.12);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 18px;
+    text-align: center;
+    overflow: hidden;
+}
+
+.error-content::before {
+    content: "";
+    position: absolute;
+    inset: 0 0 auto;
+    height: 6px;
+    background: linear-gradient(135deg, var(--primary-color), var(--accent-color));
+}
+
+.error-eyebrow {
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: rgba(106, 78, 57, 0.55);
+    margin-top: 16px;
+}
+
+.error-content h1 {
+    font-family: 'Playfair Display', 'Times New Roman', serif;
+    font-size: clamp(2rem, 4.4vw, 3rem);
+    color: var(--primary-color);
+    margin: 0;
+}
+
+.error-message,
+.error-suggestion {
+    margin: 0;
+    color: rgba(51, 51, 51, 0.8);
+    font-size: clamp(1rem, 2.5vw, 1.08rem);
+    line-height: 1.7;
+    max-width: 460px;
+}
+
+.error-suggestion {
+    font-weight: 600;
+    color: rgba(51, 51, 51, 0.85);
+}
+
+.error-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-top: 12px;
+}
+
+body.error-page .btn.primary {
+    padding: 12px 32px;
+    font-size: 1rem;
+    box-shadow: 0 22px 44px rgba(106, 78, 57, 0.28);
+}
+
+.error-actions .text-link {
+    font-weight: 600;
+}
+
+.error-footer {
+    padding: 24px 0 40px;
+    font-size: 0.92rem;
+    color: rgba(51, 51, 51, 0.6);
+    text-align: center;
+}
+
+@media (max-width: 640px) {
+    .error-logo {
+        width: 60px;
+        height: 60px;
+        border-radius: 16px;
+    }
+
+    .error-brand-name {
+        font-size: 1.3rem;
+    }
+
+    .error-brand-tagline {
+        font-size: 0.85rem;
+    }
+
+    .error-content {
+        border-radius: 28px;
+        gap: 16px;
+    }
+
+    .error-actions {
+        width: 100%;
+    }
+
+    .error-actions .btn.primary {
+        width: 100%;
+    }
+}


### PR DESCRIPTION
## Summary
- restyle the 404 page with a centered content card, subtle gradients, and typography aligned with the rest of the site
- remove the spinning logo animation and update the header/footer treatment for a calmer, minimal presentation
- add contact link and refreshed copy to guide visitors back to the homepage or reach the team

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cb25e01170832ca1f8256c6a135e87