### PR TITLE
Add order confirmation animation and cart feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -268,7 +268,7 @@
                         </li>
                     </ol>
                 </div>
-                <div id="easterOverlay" class="easteregg-overlay">
+                <div id="easterOverlay" class="easteregg-overlay" aria-hidden="true">
                     <div class="easteregg-symbol">!</div>
                 </div>
             </div>

--- a/order.html
+++ b/order.html
@@ -364,6 +364,7 @@
                     </form>
                 </div>
                 <div class="cart-summary">
+                    <div class="cart-feedback" data-cart-feedback role="status" aria-live="polite" hidden></div>
                     <div class="summary-row">
                         <span>Subtotal</span>
                         <span data-subtotal>Rp 0</span>
@@ -386,6 +387,10 @@
             </aside>
         </div>
     </main>
+
+    <div id="easterOverlay" class="easteregg-overlay" aria-hidden="true">
+        <div class="easteregg-symbol">!</div>
+    </div>
 
     <div class="modal customize-modal" id="customize-modal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
         <div class="modal-dialog">
@@ -529,6 +534,43 @@
                 <footer class="modal-footer">
                     <button type="button" class="btn ghost" data-close-modal>Batal</button>
                     <button type="button" class="btn primary" data-action="confirm-checkout">Konfirmasi Pesanan</button>
+                </footer>
+            </div>
+        </div>
+    </div>
+
+    <div class="modal success-modal" id="order-success-modal" role="dialog" aria-modal="true" aria-hidden="true" hidden>
+        <div class="modal-dialog">
+            <button type="button" class="modal-close" data-close-modal aria-label="Tutup dialog">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <div class="modal-content">
+                <header class="modal-header">
+                    <span class="modal-eyebrow">Terima Kasih</span>
+                    <h3>Pesanan Berhasil Dibuat</h3>
+                    <p>Tim kami sedang mempersiapkan minuman terbaikmu.</p>
+                </header>
+                <div class="success-body">
+                    <div class="success-icon" aria-hidden="true">🧋</div>
+                    <ul class="success-summary">
+                        <li>
+                            <span>Nomor Pesanan</span>
+                            <strong data-success-order-id>TBL-000000</strong>
+                        </li>
+                        <li>
+                            <span>Total Pembayaran</span>
+                            <strong data-success-total>Rp 0</strong>
+                        </li>
+                        <li>
+                            <span>Metode Pembayaran</span>
+                            <strong data-success-method>QRIS</strong>
+                        </li>
+                    </ul>
+                    <p class="success-note" data-success-note>Pesananmu sedang kami proses.</p>
+                </div>
+                <footer class="modal-footer">
+                    <button type="button" class="btn ghost" data-action="back-to-menu">Lihat Menu Lagi</button>
+                    <button type="button" class="btn primary" data-close-modal data-action="close-success">Siap, Terima Kasih!</button>
                 </footer>
             </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -1934,6 +1934,11 @@ body.loaded.order-page .cart-panel {
     transform: translateY(0);
 }
 
+.cart-panel.cart-panel--pulse {
+    transform: translateY(-4px);
+    box-shadow: 0 30px 46px rgba(106, 78, 57, 0.22);
+}
+
 .cart-header {
     display: flex;
     justify-content: space-between;
@@ -2144,6 +2149,32 @@ body.loaded.order-page .cart-panel {
     gap: 16px;
     border-top: 1px solid rgba(106, 78, 57, 0.12);
     padding-top: 18px;
+}
+
+.cart-feedback {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 14px 18px;
+    border-radius: 16px;
+    background: rgba(106, 78, 57, 0.1);
+    color: var(--primary-color);
+    font-weight: 600;
+    line-height: 1.4;
+    box-shadow: inset 0 0 0 1px rgba(106, 78, 57, 0.12);
+    opacity: 0;
+    transform: translateY(-6px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.cart-feedback::before {
+    content: "🧋";
+    font-size: 1.25rem;
+}
+
+.cart-feedback.is-visible {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .summary-row {
@@ -2674,6 +2705,76 @@ body.loaded.order-page .cart-panel {
     justify-content: flex-end;
 }
 
+.success-modal .modal-dialog {
+    width: min(520px, 100%);
+}
+
+.success-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 20px;
+}
+
+.success-icon {
+    width: 96px;
+    height: 96px;
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    font-size: 48px;
+    color: #ffffff;
+    background: radial-gradient(circle at top, #f7c08a, #a1704c);
+    box-shadow: 0 18px 35px rgba(106, 78, 57, 0.25);
+}
+
+.success-summary {
+    width: 100%;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.success-summary li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 14px 18px;
+    border-radius: 16px;
+    background: rgba(106, 78, 57, 0.08);
+    color: var(--primary-color);
+    font-weight: 600;
+}
+
+.success-summary li span {
+    color: rgba(106, 78, 57, 0.7);
+    font-weight: 600;
+}
+
+.success-summary li strong {
+    font-size: 1.05em;
+}
+
+.success-note {
+    width: 100%;
+    margin: 0;
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: rgba(175, 139, 101, 0.14);
+    color: rgba(33, 24, 18, 0.85);
+    line-height: 1.6;
+    font-size: 0.95em;
+}
+
+.success-modal .modal-footer {
+    justify-content: center;
+    gap: 12px;
+}
+
 .toast {
     position: fixed;
     left: 50%;
@@ -3111,6 +3212,26 @@ footer {
 
     body.order-page .menu-info-header {
         display: flex;
+    }
+
+    .success-modal .modal-dialog {
+        width: min(92vw, 100%);
+    }
+
+    .success-icon {
+        width: 80px;
+        height: 80px;
+        font-size: 40px;
+    }
+
+    .success-summary li {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 4px;
+    }
+
+    .success-summary li strong {
+        font-size: 1em;
     }
 
     .nav-toggle {


### PR DESCRIPTION
## Summary
- add a reusable boba spin animation helper and guard the easter egg handler so it works across pages
- show a success modal after the checkout animation and provide cart feedback when items are added
- style the new cart feedback banner and success modal for desktop and mobile

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d91435621c832cb7209aa37304441d